### PR TITLE
finish /g_variants implementation

### DIFF
--- a/bento_beacon/endpoints/variants.py
+++ b/bento_beacon/endpoints/variants.py
@@ -1,8 +1,7 @@
-import requests
-from flask import Blueprint, jsonify, current_app, request
-
+from flask import Blueprint, current_app, request
 from ..utils.beacon_response import beacon_response
-from ..utils.gohan_utils import query_gohan, gohan_total_variants_count
+from ..utils.gohan_utils import query_gohan, gohan_total_variants_count, gohan_totals_by_sample_id
+from ..utils.katsu_utils import katsu_filters_query
 from ..utils.exceptions import NotImplemented
 
 variants = Blueprint("variants", __name__, url_prefix="/api")
@@ -15,20 +14,44 @@ def get_variants():
     
     variants_query = beacon_args.get("query", {}).get("requestParameters", {}).get("g_variant") or {}
     filters = beacon_args.get("query", {}).get("filters") or []
+    katsu_response_ids = []
+
+    if filters: 
+        katsu_response_ids = katsu_filters_query(filters).get("results") or []
 
     # if no query, return total count of variants
     if not (variants_query or filters):
         total_count = gohan_total_variants_count()
         return beacon_response({"count": total_count})
 
+    # filters only, use sum total counts for ids 
+    if (filters and not variants_query):
+        totals_by_id = gohan_totals_by_sample_id()
+
+        # temp fix for casing issues in gohan
+        katsu_response_ids_lower = [id.lower() for id in katsu_response_ids]
+
+        intersection = list(set(totals_by_id.keys()) & set(katsu_response_ids_lower))
+        total_variants_count = sum(totals_by_id.get(id) for id in intersection)
+        return beacon_response({"count": total_variants_count})
+
+    # only variants query, use gohan count endpoint
+    if (variants_query and not filters):
+        gohan_response = query_gohan(variants_query, granularity, ids_only=False)
+        gohan_response_count = gohan_response.get("count") or 0
+        return beacon_response({"count": gohan_response_count})
+
+    # else variants query and filters
+    gohan_response = query_gohan(variants_query, "record", ids_only=False)
+    filtered_response = list(filter(lambda c: c.get("sample_id") in katsu_response_ids, gohan_response))
+    return beacon_response({"count": len(filtered_response)})
 
 
-    # TODO: if filtering terms present, call katsu and join
-    # TODO: if no query, call gohan for full count of variants
-    results = query_gohan(variants_query, granularity)
-
-    return beacon_response(results)
-
+# -------------------------------------------------------
+#       "by id" endpoints 
+# -------------------------------------------------------
+# 
+# These aren't useful for a counts-only beacon (you will never know any ids)
 
 @variants.route("/g_variants/<id>", methods=['GET', 'POST'])
 def variant_by_id(id):

--- a/bento_beacon/utils/gohan_utils.py
+++ b/bento_beacon/utils/gohan_utils.py
@@ -205,12 +205,12 @@ def gohan_network_call(url, gohan_args):
     return gohan_response
 
 
+# used internally only
 def gohan_full_record_query(gohan_args):
-    # TODO
-    # return results wrapped in this shape:
-    # { count: xx, results: [] }
-
-    raise NotImplemented("full record variant query not implemented")
+    config = current_app.config
+    query_url = config["GOHAN_BASE_URL"] + config["GOHAN_SEARCH_ENDPOINT"]
+    response = gohan_results(query_url, gohan_args)
+    return response.get("calls")
 
 
 def gohan_totals_by_sample_id():


### PR DESCRIPTION
Full implementation for `/g_variants` endpoint with count responses. Covers all four possible cases for queries including/not including filters or variant query parameters. 