### PR TITLE
fix variants count

### DIFF
--- a/bento_beacon/endpoints/variants.py
+++ b/bento_beacon/endpoints/variants.py
@@ -17,7 +17,7 @@ def get_variants():
     katsu_response_ids = []
 
     if filters: 
-        katsu_response_ids = katsu_filters_query(filters).get("results") or []
+        katsu_response_ids = katsu_filters_query(filters, get_biosample_ids=True).get("results") or []
 
     # if no query, return total count of variants
     if not (variants_query or filters):

--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -6,8 +6,8 @@ from .exceptions import APIException
 from functools import reduce
 
 
-def katsu_filters_query(beacon_filters):
-    payload = katsu_json_payload(beacon_filters)
+def katsu_filters_query(beacon_filters, get_biosample_ids=False):
+    payload = katsu_json_payload(beacon_filters, get_biosample_ids)
     response = katsu_network_call(payload)
     results = response.get("results")
     match_list = []
@@ -138,12 +138,14 @@ def bento_expression_tree(terms):
 
 
 # TODO: parameterize data_type and field
-def katsu_json_payload(filters):
+def katsu_json_payload(filters, get_biosample_ids):
+    id_type = "biosamples" if get_biosample_ids else "subject"
+
     return {
         "data_type": "phenopacket",
         "query": bento_expression_tree(filters),
         "output": "values_list",
-        "field": ["subject", "id"]
+        "field": [id_type, "id"]
     }
 
 


### PR DESCRIPTION
This fixes a logic error in some variants counts. In general, for queries covering both clinical metadata and variants, the correct procedure is to: 
- retrieve matching biosample ids from katsu
- retrieve matching biosample ids from gohan
- compute intersection

This fix corrects a bug occurring in the `/g_variants` endpoint only, where katsu was returning _subject_ ids rather than biosample ids. 