### PR TITLE
skeleton code for experiments endpoints

### DIFF
--- a/bento_beacon/app.py
+++ b/bento_beacon/app.py
@@ -8,6 +8,7 @@ from .endpoints.variants import variants
 from .endpoints.biosamples import biosamples
 from .endpoints.cohorts import cohorts
 from .endpoints.datasets import datasets
+from .endpoints.analyses import analyses
 from .utils.exceptions import APIException
 from werkzeug.exceptions import HTTPException
 from .config_files.config import Config
@@ -44,6 +45,7 @@ app.register_blueprint(variants)
 app.register_blueprint(biosamples)
 app.register_blueprint(cohorts)
 app.register_blueprint(datasets)
+app.register_blueprint(analyses)
 
 
 @app.errorhandler(Exception)

--- a/bento_beacon/endpoints/analyses.py
+++ b/bento_beacon/endpoints/analyses.py
@@ -1,0 +1,23 @@
+from flask import Blueprint
+from ..utils.exceptions import NotImplemented
+
+analyses = Blueprint("analyses", __name__)
+
+
+@analyses.route("/analyses", methods=['GET', 'POST'])
+def get_analyses():
+    # TODO
+    raise NotImplemented()
+
+
+@analyses.route("/analyses/<id>", methods=['GET', 'POST'])
+def get_experiment_by_id(id):
+    # TODO
+    # useful only if we do full-record response here
+    raise NotImplemented()
+
+
+@analyses.route("/analyses/<id>/g_variants", methods=['GET', 'POST'])
+def variants_by_experiment(id):
+    # possibly redundant to vcf handover
+    raise NotImplemented()


### PR DESCRIPTION
Starter skeleton code for `/analyses`, serving the equivalent of Bento experiment results. More to come