### PR TITLE
Features/biosample counts

### DIFF
--- a/bento_beacon/endpoints/biosamples.py
+++ b/bento_beacon/endpoints/biosamples.py
@@ -1,44 +1,52 @@
 from json import JSONDecodeError
 import requests
-from flask import Blueprint, jsonify, current_app
+from flask import Blueprint, jsonify, current_app, request
 from ..utils.exceptions import APIException, NotImplemented
+from ..utils.beacon_request import query_parameters_from_request
 from ..utils.beacon_response import beacon_response, katsu_not_found
 from ..utils.beacon_mappings import katsu_biosample_to_beacon_biosample
+from ..utils.katsu_utils import katsu_total_biosamples_count, katsu_filters_query
+from ..utils.gohan_utils import query_gohan
+
 
 biosamples = Blueprint("biosamples", __name__)
 
 
-# TODO: pass beacon filtering terms as katsu queries 
-
 @biosamples.route("/biosamples", methods=['GET', 'POST'])
 def get_biosamples():
-    # katsu_response = query_katsu(
-    #     current_app.config["KATSU_BIOSAMPLES_ENDPOINT"])
+    granularity = current_app.config["BEACON_GRANULARITY"]
 
-    # current_app.logger.info(katsu_response)
-    # if katsu_not_found(katsu_response):
-    #     current_app.logger.info("katsu not found")
-    #     return beacon_response([])
+    variants_query, filters = query_parameters_from_request()
+    sample_ids = []
 
-    # # expect response with properties "count", "next", "previous", "results"
-    # results = katsu_response.get("results")
-    # mapped_results = list(map(katsu_biosample_to_beacon_biosample, results))
-    # return beacon_response(mapped_results)
-    raise NotImplemented()
+    # if no query, return total count of biosamples
+    if not (variants_query or filters):
+        total_count = katsu_total_biosamples_count()
+        return beacon_response({"count": total_count})
+
+    if variants_query:
+        sample_ids = query_gohan(variants_query, granularity, ids_only=True)
+        # skip katsu call if no results
+        if not sample_ids:
+            return beacon_response({"count": 0})
+        # skip katsu call if no filters
+        if not filters:
+            return beacon_response({"count": len(sample_ids)})
+
+    # else filters in query
+    katsu_results = katsu_filters_query(filters, get_biosample_ids=True)
+
+    # TODO: possible overcount in this case
+    if not variants_query:
+        return beacon_response({"count": katsu_results["count"]})
+    
+    katsu_ids = katsu_results["results"]
+    intersection = list(set(katsu_ids) & set(sample_ids))
+    return beacon_response({"count": len(intersection)})
+
 
 @biosamples.route("/biosamples/<id>", methods=['GET', 'POST'])
 def get_katsu_biosamples_by_id(id):
-    # katsu_response = query_katsu(
-    #     current_app.config["KATSU_BIOSAMPLES_ENDPOINT"], id)
-
-    # current_app.logger.info(katsu_response)
-
-    # if katsu_not_found(katsu_response):
-    #     current_app.logger.info("katsu returned 'not found'")
-    #     return beacon_response([])
-
-    # mapped_repsonse = katsu_biosample_to_beacon_biosample(katsu_response)
-    # return beacon_response([mapped_repsonse])
     raise NotImplemented()
 
 @biosamples.route("/biosamples/<id>/g_variants", methods=['GET', 'POST'])

--- a/bento_beacon/utils/beacon_request.py
+++ b/bento_beacon/utils/beacon_request.py
@@ -16,6 +16,19 @@ def request_defaults():
     }
 
 
+# request read from flask request context
+def query_parameters_from_request():
+    if request.method == "POST":
+        beacon_args = request.get_json() or {}
+    else:
+        beacon_args = {}
+
+    variants_query = beacon_args.get("query", {}).get(
+        "requestParameters", {}).get("g_variant") or {}
+    filters = beacon_args.get("query", {}).get("filters") or []
+    return variants_query, filters
+
+
 def save_request_data():
     defaults = request_defaults()
 

--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -196,12 +196,19 @@ def get_filtering_term_resources():
 # -------------------------------------------------------
 
 
-def katsu_total_individuals_count():
-    c = current_app.config
-    endpoint = c["KATSU_INDIVIDUALS_ENDPOINT"]
+def katsu_counts_from_endpoint(endpoint):
     count_response = katsu_get(endpoint, query="page_size=1")
-    count = count_response.get("count")
-    return count
+    return count_response.get("count")
+
+
+def katsu_total_individuals_count():
+    endpoint = current_app.config["KATSU_INDIVIDUALS_ENDPOINT"]
+    return katsu_counts_from_endpoint(endpoint)
+
+
+def katsu_total_biosamples_count():
+    endpoint = current_app.config["KATSU_BIOSAMPLES_ENDPOINT"]
+    return katsu_counts_from_endpoint(endpoint)
 
 
 def katsu_datasets(id=None):


### PR DESCRIPTION
First pass at `/biosamples` (part of Redmine [#1423](https://206.12.92.46/issues/1423))
- count response only, can add full response later if necessary
- counts are returned as follows for four possible cases:


| | filters  | no filters |
| ------------- | ------------- | ------------- |
| **variant query**   | intersection of gohan & katsu ids | gohan sample ids |
| **no variant query** | katsu sample ids  | total biosample count |

Oustanding issue: note that in certain cases the "katsu sample ids" case may return an overcount, since katsu search returns all _individuals_ matching a search, rather than all biosamples, even if searching only biosample properties. The best solution is to modify katsu so this is possible (which appears to be part of our plans for the near future). Possible workarounds: 

- use katsu `/biosamples` endpoint instead of katsu search. But this leaves us with only a few possible filters, and none of the obvious ones, like diseases or phenotypic features.
- do special handling for the cases where overcounts will occur. But this requires managing a larger katsu response, which will be too slow for many queries. 
