### PR TITLE
handover utils

### DIFF
--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -21,6 +21,7 @@ class Config:
     KATSU_BASE_URL = os.environ.get("KATSU_BASE_URL", "http://bentov2-katsu:8000")
     KATSU_BIOSAMPLES_ENDPOINT = "/api/biosamples"
     KATSU_INDIVIDUALS_ENDPOINT = "/api/individuals"
+    KATSU_BATCH_INDIVIDUALS_ENDPOINT = "/api/batch/individuals"
     KATSU_DATASETS_ENDPOINT = "/api/datasets"
     KATSU_SEARCH_ENDPOINT = "/private/search"
     KATSU_RESOURCES_ENDPOINT = "/api/resources"
@@ -40,6 +41,13 @@ class Config:
     GOHAN_COUNT_ENDPOINT = "/variants/count/by/variantId"
     GOHAN_OVERVIEW_ENDPOINT = "/variants/overview"
     GOHAN_TIMEOUT = int(os.environ.get("BEACON_GOHAN_TIMEOUT", 60))
+
+# -------------------
+# drs
+
+    DRS_INTERNAL_URL = os.environ.get("DRS_INTERNAL_URL", "http://bentov2-drs:5000")
+    DRS_EXTERNAL_URL = os.environ.get("DRS_EXTERNAL_URL", "https://portal.bentov2.local/api/drs")
+
 
 # -------------------
 # handle injected config files

--- a/bento_beacon/utils/handover_utils.py
+++ b/bento_beacon/utils/handover_utils.py
@@ -1,7 +1,12 @@
-from flask import request, url_for
+from flask import current_app, request, url_for
+import requests
+from json import JSONDecodeError
 from urllib.parse import urlsplit, urlunsplit
+from .katsu_utils import katsu_network_call
+from .exceptions import APIException
 
 TRUNCATED_BY_GATEWAY = "api/beacon"
+DRS_TIMEOUT_SECONDS = 10
 
 
 def get_handover_url():
@@ -14,5 +19,67 @@ def get_handover_url():
         handover_path,
         base_url_components.query,
         base_url_components.fragment
-        ))
+    ))
     return handover_base_url
+
+
+def drs_network_call(path, query):
+    base_url_components = urlsplit(current_app.config["DRS_BASE_URL"])
+    url = urlunsplit((
+        base_url_components.scheme,
+        base_url_components.netloc,
+        path,
+        query,
+        base_url_components.fragment
+    ))
+    print(url)
+
+    try:
+        r = requests.get(
+            url,
+            verify=not c["DEBUG"],
+            timeout=DRS_TIMEOUT_SECONDS,
+        )
+        drs_response = r.json()
+
+    except (JSONDecodeError, requests.RequestException):
+        current_app.logger.debug("drs error")
+        raise APIException(message="error calling DRS")
+
+    return drs_response
+
+
+def drs_object_from_filename(filename):
+    response = drs_network_call("/search", f"name={filename}")
+    print(response)
+    pass
+
+
+def vcf_filenames_from_ids(ids):
+    if not ids:
+        return []
+    payload = {
+        "data_type": "phenopacket",
+        "query": ["#in", ["#resolve", "subject", "id"], ["#list", *ids]],
+        "output": "values_list",
+        "field": ["biosamples", "[item]", "experiment", "[item]", "experiment_results", "[item]", "filename"]
+    }
+    response = katsu_network_call(payload)
+    results = response.get("results")
+
+    all_files = []
+    # possibly multiple tables
+    for value in results.values():
+        if value.get("data_type") == "phenopacket":
+            all_files = all_files + value.get("matches")
+
+    # TODO: filter by file type? (vcf, cram, etc) or some other property 
+    print(all_files)
+    
+    return all_files
+
+
+def drs_link_from_vcf_filename(filename):
+    # generate https link 
+    pass
+

--- a/bento_beacon/utils/handover_utils.py
+++ b/bento_beacon/utils/handover_utils.py
@@ -142,21 +142,19 @@ def drs_link_from_vcf_filename(filename):
 def vcf_handover_entry(url, note=None):
     entry = {"handoverType": {"id": "NCIT:C172216", "label": "VCF file"},
              "url": url}
+    # optional field for extra information about this file
     if note:
         entry["note"] = note
     return entry
 
 
-def handover_links_for_ids(ids):
-    # return dict so we can preserve the connection between filename and download link
-    # ideally we could preserve link between *ids* and links,
-    # but this needs changes to katsu to do well
-    handovers = {}
+def handover_for_ids(ids):
+    # ideally we would preserve the mapping between ids and links,
+    # but this requires changes in katsu to do well
+    handovers = []
     filenames = vcf_filenames_from_ids(ids)
-
     for f in filenames:
         link = drs_link_from_vcf_filename(f)
         if link:
-            handovers[f] = link
-
+            handovers.append(vcf_handover_entry(link))
     return handovers

--- a/bento_beacon/utils/handover_utils.py
+++ b/bento_beacon/utils/handover_utils.py
@@ -124,7 +124,7 @@ def drs_link_from_vcf_filename(filename):
     # for now, just return the most recent
     ordered_by_most_recent = sorted(
         obj, key=lambda entry: entry['created_time'], reverse=True)
-    most_recent_id = ordered_by_most_recent[1].get("id")
+    most_recent_id = ordered_by_most_recent[0].get("id")
     # internal_url = drs_internal_file_link_for_id(most_recent_id)
     external_url = drs_external_file_link_for_id(most_recent_id)
     return external_url

--- a/bento_beacon/utils/handover_utils.py
+++ b/bento_beacon/utils/handover_utils.py
@@ -34,7 +34,7 @@ def drs_external_url_components():
 
 def drs_internal_file_link_for_id(id):
     internal_url_components = drs_internal_url_components()
-    path = internal_url_components.path + "/objects/" + id
+    path = internal_url_components.path + "/objects/" + id + "/download"
     return urlunsplit((
         internal_url_components.scheme,
         internal_url_components.netloc,
@@ -46,7 +46,7 @@ def drs_internal_file_link_for_id(id):
 
 def drs_external_file_link_for_id(id):
     external_url_components = drs_external_url_components()
-    path = external_url_components.path + "/objects/" + id
+    path = external_url_components.path + "/objects/" + id + "/download"
     return urlunsplit((
         "https",
         external_url_components.netloc,
@@ -139,9 +139,17 @@ def drs_link_from_vcf_filename(filename):
     return external_url
 
 
+def vcf_handover_entry(url, note=None):
+    entry = {"handoverType": {"id": "NCIT:C172216", "label": "VCF file"},
+             "url": url}
+    if note:
+        entry["note"] = note
+    return entry
+
+
 def handover_links_for_ids(ids):
     # return dict so we can preserve the connection between filename and download link
-    # ideally we could preserve link between ids and filenames,
+    # ideally we could preserve link between *ids* and links,
     # but this needs changes to katsu to do well
     handovers = {}
     filenames = vcf_filenames_from_ids(ids)

--- a/bento_beacon/utils/handover_utils.py
+++ b/bento_beacon/utils/handover_utils.py
@@ -1,0 +1,18 @@
+from flask import request, url_for
+from urllib.parse import urlsplit, urlunsplit
+
+TRUNCATED_BY_GATEWAY = "api/beacon"
+
+
+def get_handover_url():
+    base_url_components = urlsplit(request.url)
+    handover_scheme = "https"
+    handover_path = TRUNCATED_BY_GATEWAY + url_for("handover.get_handover")
+    handover_base_url = urlunsplit((
+        handover_scheme,
+        base_url_components.netloc,
+        handover_path,
+        base_url_components.query,
+        base_url_components.fragment
+        ))
+    return handover_base_url

--- a/bento_beacon/utils/handover_utils.py
+++ b/bento_beacon/utils/handover_utils.py
@@ -111,7 +111,9 @@ def filenames_from_ids(ids):
             all_files = all_files + value.get("matches")
 
     # TODO: filter by file type? (vcf, cram, etc) or some other property
-    return all_files
+
+    # remove any duplicates (possible with multisample vcfs)
+    return list(set(all_files))
 
 
 def drs_link_from_vcf_filename(filename):

--- a/bento_beacon/utils/handover_utils.py
+++ b/bento_beacon/utils/handover_utils.py
@@ -5,23 +5,23 @@ from .katsu_utils import katsu_network_call
 from .exceptions import APIException
 
 # path elements removed by bento gateway
-BEACON_PATH_FRAGMENT = "api/beacon"
+# BEACON_PATH_FRAGMENT = "api/beacon"
 
 DRS_TIMEOUT_SECONDS = 10
 
-
-def get_handover_url():
-    base_url_components = urlsplit(request.url)
-    handover_scheme = "https"
-    handover_path = BEACON_PATH_FRAGMENT + url_for("handover.get_handover")
-    handover_base_url = urlunsplit((
-        handover_scheme,
-        base_url_components.netloc,
-        handover_path,
-        base_url_components.query,
-        base_url_components.fragment
-    ))
-    return handover_base_url
+# may or may not be needed
+# def get_handover_url():
+#     base_url_components = urlsplit(request.url)
+#     handover_scheme = "https"
+#     handover_path = BEACON_PATH_FRAGMENT + url_for("handover.get_handover")
+#     handover_base_url = urlunsplit((
+#         handover_scheme,
+#         base_url_components.netloc,
+#         handover_path,
+#         base_url_components.query,
+#         base_url_components.fragment
+#     ))
+#     return handover_base_url
 
 
 def drs_internal_url_components():
@@ -32,16 +32,16 @@ def drs_external_url_components():
     return urlsplit(current_app.config["DRS_EXTERNAL_URL"])
 
 # TODO: either remove or deduplicate with below
-def drs_internal_file_link_for_id(id):
-    internal_url_components = drs_internal_url_components()
-    path = internal_url_components.path + "/objects/" + id + "/download"
-    return urlunsplit((
-        internal_url_components.scheme,
-        internal_url_components.netloc,
-        path,
-        internal_url_components.query,
-        internal_url_components.fragment
-    ))
+# def drs_internal_file_link_for_id(id):
+#     internal_url_components = drs_internal_url_components()
+#     path = internal_url_components.path + "/objects/" + id + "/download"
+#     return urlunsplit((
+#         internal_url_components.scheme,
+#         internal_url_components.netloc,
+#         path,
+#         internal_url_components.query,
+#         internal_url_components.fragment
+#     ))
 
 
 def drs_external_file_link_for_id(id):
@@ -126,7 +126,7 @@ def drs_link_from_vcf_filename(filename):
     ordered_by_most_recent = sorted(
         obj, key=lambda entry: entry['created_time'], reverse=True)
     most_recent_id = ordered_by_most_recent[1].get("id")
-    internal_url = drs_internal_file_link_for_id(most_recent_id)
+    # internal_url = drs_internal_file_link_for_id(most_recent_id)
     external_url = drs_external_file_link_for_id(most_recent_id)
     return external_url
 

--- a/bento_beacon/utils/handover_utils.py
+++ b/bento_beacon/utils/handover_utils.py
@@ -31,7 +31,7 @@ def drs_internal_url_components():
 def drs_external_url_components():
     return urlsplit(current_app.config["DRS_EXTERNAL_URL"])
 
-
+# TODO: either remove or deduplicate with below
 def drs_internal_file_link_for_id(id):
     internal_url_components = drs_internal_url_components()
     path = internal_url_components.path + "/objects/" + id + "/download"
@@ -65,7 +65,6 @@ def drs_network_call(path, query):
         query,
         base_url_components.fragment
     ))
-    print(url)
 
     try:
         r = requests.get(
@@ -91,7 +90,7 @@ def drs_object_from_filename(filename):
     return response
 
 
-def vcf_filenames_from_ids(ids):
+def filenames_from_ids(ids):
     if not ids:
         return []
 
@@ -113,8 +112,6 @@ def vcf_filenames_from_ids(ids):
             all_files = all_files + value.get("matches")
 
     # TODO: filter by file type? (vcf, cram, etc) or some other property
-    print(all_files)
-
     return all_files
 
 
@@ -129,13 +126,8 @@ def drs_link_from_vcf_filename(filename):
     ordered_by_most_recent = sorted(
         obj, key=lambda entry: entry['created_time'], reverse=True)
     most_recent_id = ordered_by_most_recent[1].get("id")
-
     internal_url = drs_internal_file_link_for_id(most_recent_id)
     external_url = drs_external_file_link_for_id(most_recent_id)
-
-    print(f"internal url: {internal_url}")
-    print(f"external url: {external_url}")
-
     return external_url
 
 
@@ -152,7 +144,7 @@ def handover_for_ids(ids):
     # ideally we would preserve the mapping between ids and links,
     # but this requires changes in katsu to do well
     handovers = []
-    filenames = vcf_filenames_from_ids(ids)
+    filenames = filenames_from_ids(ids)
     for f in filenames:
         link = drs_link_from_vcf_filename(f)
         if link:

--- a/bento_beacon/utils/handover_utils.py
+++ b/bento_beacon/utils/handover_utils.py
@@ -74,6 +74,10 @@ def drs_network_call(path, query):
         )
         drs_response = r.json()
 
+    # TODO, ideally after auth merge:
+    # on handover errors, keep returning rest of results instead of throwing api exception
+    # add optional note in g and add to beacon response
+    # return {}
     except requests.exceptions.RequestException as e:
         current_app.logger.debug(f"drs error: {e.msg}")
         raise APIException(message="error generating handover links")
@@ -82,12 +86,7 @@ def drs_network_call(path, query):
 
 
 def drs_object_from_filename(filename):
-    response = drs_network_call("/search", f"name={filename}")
-
-    # if nothing return None
-
-    print(response)
-    return response
+    return drs_network_call("/search", f"name={filename}")
 
 
 def filenames_from_ids(ids):

--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -40,9 +40,12 @@ def katsu_filters_and_sample_ids_query(beacon_filters, sample_ids):
     return katsu_filters_query(filters_and_in)
 
 
-def katsu_network_call(payload):
+def katsu_network_call(payload, endpoint=None):
     c = current_app.config
-    url = c["KATSU_BASE_URL"] + c["KATSU_SEARCH_ENDPOINT"]
+
+    # awkward default since current_app not available in function params
+    endpoint = c["KATSU_SEARCH_ENDPOINT"] if endpoint is None else endpoint
+    url = c["KATSU_BASE_URL"] + endpoint
     current_app.logger.debug(f'calling katsu url {url}')
 
     try:
@@ -215,3 +218,15 @@ def katsu_datasets(id=None):
         return response.get("results")  # collection
 
     return response  # single dataset
+
+
+def phenopackets_for_ids(ids):
+    # call /batch/individuals
+    payload = {
+        "id": [*ids],
+        "format": "phenopackets"
+    }
+    endpoint = current_app.config["KATSU_BATCH_INDIVIDUALS_ENDPOINT"]
+    result = katsu_network_call(payload, endpoint)
+
+    return result


### PR DESCRIPTION
Add utils for [beacon handover](http://docs.genomebeacons.org/beacon-flavours/?h=handover#ho-beacon-handovers-for-data-delivery), mostly code for generating collections of DRS links for a given set of ids, any of which may or may not have files available. 

Includes several blocks of commented code needed in case we decide to route files through beacon instead of providing direct DRS links. These can be kept or removed as needed. 