### PR TITLE
Features/improved config

### DIFF
--- a/bento_beacon/app.py
+++ b/bento_beacon/app.py
@@ -16,6 +16,7 @@ from .utils.beacon_request import save_request_data, validate_request
 from .utils.beacon_response import init_response_data
 
 REQUEST_SPEC_RELATIVE_PATH = "beacon-v2/framework/json/requests/"
+BEACON_MODELS = ["analyses", "biosamples", "cohorts", "datasets", "individuals", "runs", "variants"]
 
 app = Flask(__name__)
 
@@ -54,6 +55,8 @@ blueprints = {
 with app.app_context():
     endpoint_sets = current_app.config["BEACON_CONFIG"].get("endpointSets")
     for endpoint_set in endpoint_sets:
+        if endpoint_set not in BEACON_MODELS:
+            raise APIException(message="beacon config contains unknown endpoint set")
         app.register_blueprint(blueprints[endpoint_set])
 
 

--- a/bento_beacon/app.py
+++ b/bento_beacon/app.py
@@ -5,7 +5,7 @@ from urllib.parse import urlunsplit
 from .endpoints.info import info
 from .endpoints.individuals import individuals
 from .endpoints.variants import variants
-# from .endpoints.biosamples import biosamples
+from .endpoints.biosamples import biosamples
 from .endpoints.cohorts import cohorts
 from .endpoints.datasets import datasets
 from .utils.exceptions import APIException
@@ -38,21 +38,30 @@ logging.basicConfig(
     ]
 )
 
+# blueprints
+# always load info endpoints, load everything else based on config
+
+app.register_blueprint(info)
+
+blueprints = {
+    "biosamples": biosamples,
+    "cohorts": cohorts,
+    "datasets": datasets,
+    "individuals": individuals,
+    "variants": variants,
+}
+
+with app.app_context():
+    endpoint_sets = current_app.config["BEACON_CONFIG"].get("endpointSets")
+    for endpoint_set in endpoint_sets:
+        app.register_blueprint(blueprints[endpoint_set])
+
 
 @app.before_request
 def before_request():
     validate_request()
     save_request_data()
     init_response_data()
-
-
-# routes
-app.register_blueprint(info)
-app.register_blueprint(individuals)
-app.register_blueprint(variants)
-# app.register_blueprint(biosamples)
-app.register_blueprint(cohorts)
-app.register_blueprint(datasets)
 
 
 @app.errorhandler(Exception)

--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -5,8 +5,10 @@ import os
 class Config:
     DEBUG = os.environ.get("BEACON_DEBUG", False)
 
-    # version of ga4gh beacon spec, not version of this implementation
-    BEACON_API_VERSION = "v2.0.0"
+    BEACON_SPEC_VERSION = "v2.0.0"
+
+    # version of this implementation
+    BENTO_BEACON_VERSION = os.environ.get("BENTO_BEACON_VERSION")
 
     SMALL_CELL_COUNT_THRESHOLD = int(os.environ.get(
         "BEACON_SMALL_CELL_COUNT_THRESHOLD", 5))
@@ -22,6 +24,8 @@ class Config:
         "datasets": "record",
         "info": "record"
     }
+
+    BEACON_BASE_URL = os.environ.get("BEACON_BASE_URL")
 
 # -------------------
 # katsu
@@ -54,7 +58,7 @@ class Config:
     GOHAN_COUNT_ENDPOINT = "/variants/count/by/variantId"
     GOHAN_OVERVIEW_ENDPOINT = "/variants/overview"
     GOHAN_TIMEOUT = int(os.environ.get("BEACON_GOHAN_TIMEOUT", 60))
-    USE_GOHAN = os.environ.get("BEACON_USE_GOHAN", True)
+    # USE_GOHAN = os.environ.get("BEACON_USE_GOHAN", True)
 
 # -------------------
 # drs
@@ -91,8 +95,8 @@ class Config:
     BEACON_MAP = retrieve_config_json("beacon_map.json")
 
     # TODO: parameterize, merge with beacon service info
-    BEACON_GA4GH_SERVICE_INFO = retrieve_config_json(
-        "beacon_ga4gh_service_info.json")
+    # BEACON_GA4GH_SERVICE_INFO = retrieve_config_json(
+    #     "beacon_ga4gh_service_info.json")
 
     BEACON_COHORT = retrieve_config_json("beacon_cohort.json")
 

--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -37,7 +37,8 @@ class Config:
                 "name": "Default schema for biosamples",
                     "referenceToSchemaDefinition": "https://github.com/ga4gh-beacon/beacon-v2/blob/main/models/json/beacon-v2-default-model/biosamples/defaultSchema.json",
                     "schemaVersion": "v2.0.0"
-            }
+            },
+            "partOfSpecification": "Beacon v2.0.0"
         },
         "cohorts": {
             "entryType": "cohort",
@@ -48,7 +49,9 @@ class Config:
                 "name": "Default schema for cohorts",
                     "referenceToSchemaDefinition": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/models/json/beacon-v2-default-model/cohorts/defaultSchema.json",
                     "schemaVersion": "v2.0.0"
-            }
+            },
+            "partOfSpecification": "Beacon v2.0.0"
+
         },
         "datasets": {
             "entryType": "dataset",
@@ -59,16 +62,24 @@ class Config:
                 "name": "Default schema for datasets",
                         "referenceToSchemaDefinition": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/models/json/beacon-v2-default-model/datasets/defaultSchema.json",
                         "schemaVersion": "v2.0.0"
-            }
+            },
+            "partOfSpecification": "Beacon v2.0.0"
+
         },
         "individuals": {
             "entryType": "individual",
             "name": "Individual",
             "ontologyTermForThisType":  {"id": "NCIT:C25190", "label": "Person"},
-            "defaultSchema": "https://raw.githubusercontent.com/phenopackets/phenopacket-schema/master/src/main/proto/phenopackets/schema/v1/phenopackets.proto"
+            "defaultSchema": {
+                "id": "phenopacket-v1",
+                "name": "phenopacket v1",
+                        "referenceToSchemaDefinition": "https://raw.githubusercontent.com/phenopackets/phenopacket-schema/master/src/main/proto/phenopackets/schema/v1/phenopackets.proto",
+                        "schemaVersion": "v1.0.0"
+            },
+            "partOfSpecification": "Phenopacket v1"
         },
         "variants": {
-            "entryType": "genomicVariant",
+            "entryType": "genomicVariation",
             "name": "Genomic Variant",
             "ontologyTermForThisType":  {"id": "ENSGLOSSARY:0000092", "label": "Variant"},
             "defaultSchema": {
@@ -76,7 +87,9 @@ class Config:
                 "name": "Default schema for a genomic variation",
                         "referenceToSchemaDefinition": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json",
                         "schemaVersion": "v2.0.0"
-            }
+            },
+            "partOfSpecification": "Beacon v2.0.0"
+
         }
     }
 # -------------------
@@ -137,17 +150,6 @@ class Config:
         except FileNotFoundError:
             # TODO: proper error response
             return {"message": "Beacon error, missing config file"}
-
-    # BEACON_SERVICE_INFO = retrieve_config_json("beacon_service_info.json")
-
-    BEACON_CONFIGURATION = retrieve_config_json("beacon_configuration.json")
-
-    # TODO: correct paths with BENTO_URL
-    # BEACON_MAP = retrieve_config_json("beacon_map.json")
-
-    # TODO: parameterize, merge with beacon service info
-    # BEACON_GA4GH_SERVICE_INFO = retrieve_config_json(
-    #     "beacon_ga4gh_service_info.json")
 
     BEACON_COHORT = retrieve_config_json("beacon_cohort.json")
 

--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -123,7 +123,6 @@ class Config:
     GOHAN_COUNT_ENDPOINT = "/variants/count/by/variantId"
     GOHAN_OVERVIEW_ENDPOINT = "/variants/overview"
     GOHAN_TIMEOUT = int(os.environ.get("BEACON_GOHAN_TIMEOUT", 60))
-    # USE_GOHAN = os.environ.get("BEACON_USE_GOHAN", True)
 
 # -------------------
 # drs

--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -95,3 +95,5 @@ class Config:
         "beacon_ga4gh_service_info.json")
 
     BEACON_COHORT = retrieve_config_json("beacon_cohort.json")
+
+    BEACON_CONFIG = retrieve_config_json("beacon_config.json")

--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -27,6 +27,58 @@ class Config:
 
     BEACON_BASE_URL = os.environ.get("BEACON_BASE_URL")
 
+    ENTRY_TYPES_DETAILS = {
+        "biosamples": {
+            "entryType": "biosample",
+            "name": "Biosample",
+            "ontologyTermForThisType": {"id": "NCIT:C70699", "label": "Biospecimen"},
+            "defaultSchema": {
+                "id": "ga4gh-beacon-biosample-v2.0.0",
+                "name": "Default schema for biosamples",
+                    "referenceToSchemaDefinition": "https://github.com/ga4gh-beacon/beacon-v2/blob/main/models/json/beacon-v2-default-model/biosamples/defaultSchema.json",
+                    "schemaVersion": "v2.0.0"
+            }
+        },
+        "cohorts": {
+            "entryType": "cohort",
+            "name": "Cohort",
+            "ontologyTermForThisType": {"id": "NCIT:C61512", "label": "Cohort"},
+            "defaultSchema": {
+                "id": "ga4gh-beacon-cohort-v2.0.0",
+                "name": "Default schema for cohorts",
+                    "referenceToSchemaDefinition": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/models/json/beacon-v2-default-model/cohorts/defaultSchema.json",
+                    "schemaVersion": "v2.0.0"
+            }
+        },
+        "datasets": {
+            "entryType": "dataset",
+            "name": "Dataset",
+            "ontologyTermForThisType":  {"id": "NCIT:C47824", "label": "Data set"},
+            "defaultSchema": {
+                "id": "ga4gh-beacon-dataset-v2.0.0",
+                "name": "Default schema for datasets",
+                        "referenceToSchemaDefinition": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/models/json/beacon-v2-default-model/datasets/defaultSchema.json",
+                        "schemaVersion": "v2.0.0"
+            }
+        },
+        "individuals": {
+            "entryType": "individual",
+            "name": "Individual",
+            "ontologyTermForThisType":  {"id": "NCIT:C25190", "label": "Person"},
+            "defaultSchema": "https://raw.githubusercontent.com/phenopackets/phenopacket-schema/master/src/main/proto/phenopackets/schema/v1/phenopackets.proto"
+        },
+        "variants": {
+            "entryType": "genomicVariant",
+            "name": "Genomic Variant",
+            "ontologyTermForThisType":  {"id": "ENSGLOSSARY:0000092", "label": "Variant"},
+            "defaultSchema": {
+                "id": "ga4gh-beacon-variant-v2.0.0",
+                "name": "Default schema for a genomic variation",
+                        "referenceToSchemaDefinition": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json",
+                        "schemaVersion": "v2.0.0"
+            }
+        }
+    }
 # -------------------
 # katsu
 
@@ -66,7 +118,6 @@ class Config:
     DRS_INTERNAL_URL = os.environ.get("DRS_INTERNAL_URL")
     DRS_EXTERNAL_URL = os.environ.get("DRS_EXTERNAL_URL")
 
-
 # -------------------
 # handle injected config files
 #   a) obtain reference to the expected configuration files' location by
@@ -87,12 +138,12 @@ class Config:
             # TODO: proper error response
             return {"message": "Beacon error, missing config file"}
 
-    BEACON_SERVICE_INFO = retrieve_config_json("beacon_service_info.json")
+    # BEACON_SERVICE_INFO = retrieve_config_json("beacon_service_info.json")
 
     BEACON_CONFIGURATION = retrieve_config_json("beacon_configuration.json")
 
     # TODO: correct paths with BENTO_URL
-    BEACON_MAP = retrieve_config_json("beacon_map.json")
+    # BEACON_MAP = retrieve_config_json("beacon_map.json")
 
     # TODO: parameterize, merge with beacon service info
     # BEACON_GA4GH_SERVICE_INFO = retrieve_config_json(

--- a/bento_beacon/endpoints/cohorts.py
+++ b/bento_beacon/endpoints/cohorts.py
@@ -9,9 +9,8 @@ cohorts = Blueprint("cohorts", __name__)
 def get_cohorts():
     granularity = current_app.config["DEFAULT_GRANULARITY"]["cohorts"]
 
-    # single cohort
     cohort = current_app.config["BEACON_COHORT"]
-    results = {"collections": [cohort]}
+    results = {"collections": cohort}
     return beacon_response(results, collection_response=True)
 
 

--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -27,7 +27,7 @@ def overview():
 # service-info in ga4gh format
 @info.route("/service-info")
 def service_info():
-    return getattr(current_app.config, "BEACON_GA4GH_SERVICE_INFO", build_ga4gh_service_info())
+    return current_app.config.get("BEACON_GA4GH_SERVICE_INFO", build_ga4gh_service_info())
 
 
 # service info in beacon format

--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -7,8 +7,11 @@ from ..utils.gohan_utils import gohan_counts_by_assembly_id
 info = Blueprint("info", __name__)
 
 
+JSON_SCHEMA = "https://json-schema.org/draft/2020-12/schema"
+
+
 def overview():
-    if current_app.config["USE_GOHAN"]:
+    if current_app.config["BEACON_CONFIG"].get("useGohan"):
         variants_count = gohan_counts_by_assembly_id()
     else:
         variants_count = {}
@@ -24,39 +27,108 @@ def overview():
 # service-info in ga4gh format
 @info.route("/service-info")
 def service_info():
-    return current_app.config["BEACON_GA4GH_SERVICE_INFO"]
+    return getattr(current_app.config, "BEACON_GA4GH_SERVICE_INFO", build_ga4gh_service_info())
 
 
 # service info in beacon format
 @info.route("/")
 def beacon_info():
-    return beacon_info_response(current_app.config["BEACON_SERVICE_INFO"])
+    return current_app.config["BEACON_CONFIG"].get("serviceInfo")
 
 
 # as above but with beacon overview details
 @info.route("/info")
 def beacon_info_with_overview():
-    return beacon_info_response({**current_app.config["BEACON_SERVICE_INFO"], "overview": overview()})
+    return beacon_info_response({**current_app.config["BEACON_CONFIG"].get("serviceInfo"), "overview": overview()})
 
 
 @info.route("/filtering_terms")
+# TODO
 def filtering_terms():
     resources = get_filtering_term_resources()
     filtering_terms = get_filtering_terms()
     return beacon_info_response({"resources": resources, "filteringTerms": filtering_terms})
 
 
+# distinct from "BEACON_CONFIG"
 @info.route("/configuration")
 def beacon_configuration():
-    return beacon_info_response(current_app.config["BEACON_CONFIGURATION"])
+    return current_app.config.get("CONFIGURATION_ENDPOINT_RESPONSE", build_configuration_endpoint_response())
 
 
 @info.route("/entry_types")
 def entry_types():
-    entry_types = current_app.config["BEACON_CONFIGURATION"].get("entryTypes")
-    return beacon_info_response({"entryTypes": entry_types})
+    return current_app.config.get("ENTRY_TYPES", build_entry_types())
 
 
 @info.route("/map")
 def beacon_map():
-    return beacon_info_response(current_app.config["BEACON_MAP"])
+    return current_app.config.get("BEACON_MAP", build_beacon_map())
+
+
+# -------------------------------------------------------
+
+# utility functions for building responses
+# these return the appropriate response but also save as a side effect
+
+
+def build_ga4gh_service_info():
+    service_info = current_app.config["BEACON_CONFIG"].get("serviceInfo")
+    service_info["type"] = {
+        "artifact": "Beacon v2",
+        "group": "org.ga4gh",
+        "version": current_app.config["BEACON_SPEC_VERSION"]
+    }
+    service_info["version"] = current_app.config["BENTO_BEACON_VERSION"]
+    service_info["bento"] = {"serviceKind": "beacon"}
+    current_app.config["BEACON_GA4GH_SERVICE_INFO"] = service_info
+    return service_info
+
+
+def build_configuration_endpoint_response():
+    entry_types_details = current_app.config.get("ENTRY_TYPES", build_entry_types())
+
+    # production status is one of "DEV", "PROD", "TEST"
+    # while environment is one of "dev", "prod", "test", "staging".. generally only need "dev" and "prod"
+    production_status = current_app.config["BEACON_CONFIG"].get("serviceInfo", {}).get("environment", "error").upper()
+
+    response = {
+        "$schema": JSON_SCHEMA,
+        "entryTypes": entry_types_details,
+        "maturityAttributes": {"productionStatus": production_status}
+    }
+    current_app.config["CONFIGURATION_ENDPOINT_RESPONSE"] = response
+    return response
+
+
+def build_entry_types():
+    entry_types_response = {}
+    endpoint_sets = current_app.config["BEACON_CONFIG"].get("endpointSets")
+    entry_types_details = current_app.config["ENTRY_TYPES_DETAILS"]
+    for endpoint_set in endpoint_sets:
+        entry = entry_types_details.get(endpoint_set)
+        entry_type_name = entry.get("entryType")
+
+        entry_types_response[entry_type_name] = {
+            "id": entry_type_name,
+            "name": entry.get("name"),
+            "ontologyTermForThisType": entry.get("ontologyTermForThisType"),
+            "partOfSpecification": entry.get("partOfSpecification"),
+            "defaultSchema": entry.get("defaultSchema")
+        }
+
+    current_app.config["ENTRY_TYPES"] = entry_types_response
+    return entry_types_response
+
+
+def build_beacon_map():
+    beacon_map = {}
+    endpoint_sets = current_app.config["BEACON_CONFIG"].get("endpointSets")
+    for endpoint_set in endpoint_sets:
+        resource_name = "g_variants" if endpoint_set == "variants" else endpoint_set
+        root_url = current_app.config["BEACON_BASE_URL"] + "/" + resource_name
+        entry_type = current_app.config["ENTRY_TYPES_DETAILS"].get(endpoint_set, {}).get("entryType")
+        beacon_map[entry_type] = {"rootUrl": root_url, "entryType": entry_type}
+
+    current_app.config["BEACON_MAP"] = beacon_map
+    return beacon_map

--- a/bento_beacon/utils/beacon_request.py
+++ b/bento_beacon/utils/beacon_request.py
@@ -5,7 +5,7 @@ from .exceptions import InvalidQuery
 
 def request_defaults():
     return {
-        "apiVersion": current_app.config["BEACON_API_VERSION"],
+        "apiVersion": current_app.config["BEACON_SPEC_VERSION"],
         "granularity": current_app.config["DEFAULT_GRANULARITY"].get(request.blueprint, None),
         "includeResultsetResponses": "ALL",
         "pagination": {

--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -70,11 +70,11 @@ def received_request():
 def build_response_meta():
     returned_schemas = g.get("response_data", {}).get("returnedSchemas", [])
     returned_granularity = g.get("response_data", {}).get("returnedGranularity", "count")
-    service_info = current_app.config["BEACON_SERVICE_INFO"]
+    service_info = current_app.config["BEACON_CONFIG"].get("serviceInfo")
     received_request_summary = received_request()
     return {
         "beaconId": service_info.get("id"),
-        "apiVersion": service_info.get("apiVersion"),
+        "apiVersion": current_app.config["BEACON_SPEC_VERSION"],   
         "returnedSchemas": returned_schemas,
         "returnedGranularity": returned_granularity,
         "receivedRequestSummary": received_request_summary
@@ -82,10 +82,10 @@ def build_response_meta():
 
 
 def build_info_response_meta():
-    service_info = current_app.config["BEACON_SERVICE_INFO"]
+    service_info = current_app.config["BEACON_CONFIG"].get("serviceInfo")
     return {
         "beaconId": service_info.get("id"),
-        "apiVersion": service_info.get("apiVersion"),
+        "apiVersion": current_app.config["BEACON_SPEC_VERSION"],
         "returnedSchemas": []
     }
 


### PR DESCRIPTION
Config improvements:

- endpoints can now be toggled on / off in a config file passed at startup, so that beacons are easily adapted to different use cases (we may want / not want to serve variants, biosamples, etc) 
- replaced previous klunky implementation of information endpoint responses with a more sensible programmatic approach that's easier to use and less error-prone.
- requires bento 12