### PR TITLE
Fixes/correct environment in service info

### DIFF
--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -20,6 +20,11 @@ class Config:
 
     BEACON_BASE_URL = os.environ.get("BEACON_BASE_URL")
 
+    # reverse domain id
+    BEACON_ID = ".".join(reversed(os.environ.get("BENTOV2_DOMAIN").split("."))) + ".beacon"
+
+    BEACON_NAME = os.environ.get("BENTO_PUBLIC_CLIENT_NAME", "BENTO") + " Beacon"
+
     ENTRY_TYPES_DETAILS = {
         "biosamples": {
             "entryType": "biosample",

--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -3,8 +3,6 @@ import os
 
 
 class Config:
-    DEBUG = os.environ.get("BEACON_DEBUG", False)
-
     BEACON_SPEC_VERSION = "v2.0.0"
 
     # version of this implementation

--- a/bento_beacon/utils/gohan_utils.py
+++ b/bento_beacon/utils/gohan_utils.py
@@ -181,7 +181,6 @@ def gohan_network_call(url, gohan_args):
     try:
         r = requests.get(
             url,
-            verify=not c["DEBUG"],
             timeout=c["GOHAN_TIMEOUT"],
             params=gohan_args
         )

--- a/bento_beacon/utils/handover_utils.py
+++ b/bento_beacon/utils/handover_utils.py
@@ -69,7 +69,6 @@ def drs_network_call(path, query):
     try:
         r = requests.get(
             url,
-            verify=not current_app.config["DEBUG"],
             timeout=DRS_TIMEOUT_SECONDS,
         )
         drs_response = r.json()

--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -54,7 +54,6 @@ def katsu_network_call(payload, endpoint=None):
     try:
         r = requests.post(
             url,
-            verify=not c["DEBUG"],
             timeout=c["KATSU_TIMEOUT"],
             json=payload
         )
@@ -81,7 +80,6 @@ def katsu_network_call(payload, endpoint=None):
 def katsu_get(endpoint, id=None, query=""):
     c = current_app.config
     katsu_base_url = c["KATSU_BASE_URL"]
-    verify_certificates = not c["DEBUG"]
     timeout = current_app.config["KATSU_TIMEOUT"]
 
     # construct request url
@@ -100,7 +98,6 @@ def katsu_get(endpoint, id=None, query=""):
     try:
         r = requests.get(
             query_url,
-            verify=verify_certificates,
             timeout=timeout
         )
         katsu_response = r.json()


### PR DESCRIPTION
Service info changes: 

- Redmine #1697
  - autogenerate beacon ids in reverse-domain format
  - autogenerate beacon name (from `BENTO_PUBLIC_CLIENT_NAME` or a default)

- Redmine #1660
  - fix "environment" field, previously hardcoded to `dev`, now correctly shows `dev` or `prod`. 