### PR TITLE
Features/handle gohan errors

### DIFF
--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, current_app
 from ..utils.beacon_response import beacon_info_response
 from ..utils.katsu_utils import get_filtering_terms, get_filtering_term_resources, katsu_total_individuals_count, katsu_get
-from ..utils.gohan_utils import gohan_counts_for_overview
+from ..utils.gohan_utils import gohan_counts_for_overview, useGohan
 
 
 info = Blueprint("info", __name__)
@@ -11,7 +11,7 @@ JSON_SCHEMA = "https://json-schema.org/draft/2020-12/schema"
 
 
 def overview():
-    if current_app.config["BEACON_CONFIG"].get("useGohan"):
+    if current_app.config["BEACON_CONFIG"].get("useGohan").strip().lower() in ('true', '1', 't'):
         variants_count = gohan_counts_for_overview()
     else:
         variants_count = {}

--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -18,7 +18,7 @@ JSON_SCHEMA = "https://json-schema.org/draft/2020-12/schema"
 
 
 def overview():
-    if current_app.config["BEACON_CONFIG"].get("useGohan").strip().lower() in ('true', '1', 't'):
+    if current_app.config["BEACON_CONFIG"].get("useGohan"):
         variants_count = gohan_counts_for_overview()
     else:
         variants_count = {}

--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -115,10 +115,9 @@ def received_request():
 def build_response_meta():
     returned_schemas = g.get("response_data", {}).get("returnedSchemas", [])
     returned_granularity = g.get("response_data", {}).get("returnedGranularity", "count")
-    service_info = current_app.config["BEACON_CONFIG"].get("serviceInfo")
     received_request_summary = received_request()
     return {
-        "beaconId": service_info.get("id"),
+        "beaconId": current_app.config["BEACON_ID"],
         "apiVersion": current_app.config["BEACON_SPEC_VERSION"],   
         "returnedSchemas": returned_schemas,
         "returnedGranularity": returned_granularity,
@@ -127,9 +126,8 @@ def build_response_meta():
 
 
 def build_info_response_meta():
-    service_info = current_app.config["BEACON_CONFIG"].get("serviceInfo")
     return {
-        "beaconId": service_info.get("id"),
+        "beaconId": current_app.config["BEACON_ID"],
         "apiVersion": current_app.config["BEACON_SPEC_VERSION"],
         "returnedSchemas": []
     }

--- a/bento_beacon/utils/gohan_utils.py
+++ b/bento_beacon/utils/gohan_utils.py
@@ -228,11 +228,11 @@ def gohan_counts_by_assembly_id():
     return gohan_overview().get("assemblyIDs", {})
 
 
-# gohan /variants/overview hangs when no variants table
-# so check for a table before calling
 def gohan_counts_for_overview():
+    # gohan /variants/overview hangs when no variants table
+    # so check for tables before calling
     tables_url = current_app.config["GOHAN_BASE_URL"] + "/tables?data-type=variant"
-    tables = []
+    tables = None
 
     try:
         tables = gohan_network_call(tables_url, {})
@@ -240,10 +240,15 @@ def gohan_counts_for_overview():
         # note this exception but don't rethrow
         current_app.logger.error("cannot reach gohan for overview")
     
+    # non-empty tables
     if tables:
         return gohan_counts_by_assembly_id()
+    
+    # empty tables (fresh instance or elasticsearch down)
+    if tables is not None:
+        return {}
 
-    # either api is dead or elasticsearch is down
+    # else bad response from gohan
     return {"error": "gohan unavailable"}
 
 # --------------------------------------------

--- a/bento_beacon/utils/gohan_utils.py
+++ b/bento_beacon/utils/gohan_utils.py
@@ -228,6 +228,7 @@ def gohan_counts_by_assembly_id():
     return gohan_overview().get("assemblyIDs", {})
 
 
+# only runs if "useGohan" true
 def gohan_counts_for_overview():
     # gohan /variants/overview hangs when no variants table
     # so check for tables before calling
@@ -245,8 +246,9 @@ def gohan_counts_for_overview():
         return gohan_counts_by_assembly_id()
     
     # empty tables (fresh instance or elasticsearch down)
+    # "useGohan" is true here so we expect variants to exist
     if tables is not None:
-        return {}
+        return {"error": "no variants available"}
 
     # else bad response from gohan
     return {"error": "gohan unavailable"}


### PR DESCRIPTION
More consistent handling of errors or unexpected responses from gohan `/tables` endpoint, required for smoother behaviour in bento_public, which needs to be able to tell the difference between:

- variants missing because of an error
- variants missing because we don't expect there to be any variants (ie `useGohan` false)

Also unrelated bonus commit [0b52ff2](https://github.com/bento-platform/bento_beacon/commit/0b52ff215630db137e9eb0959c64b06a45642a3e), fixing an error in beacon response meta.