### PR TITLE
better individual schema reference

### DIFF
--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -75,7 +75,7 @@ class Config:
             "defaultSchema": {
                 "id": "phenopacket-v1",
                 "name": "phenopacket v1",
-                        "referenceToSchemaDefinition": "https://raw.githubusercontent.com/phenopackets/phenopacket-schema/master/src/main/proto/phenopackets/schema/v1/phenopackets.proto",
+                        "referenceToSchemaDefinition": f"{BEACON_BASE_URL}/individual_schema",
                         "schemaVersion": "v1.0.0"
             },
             "partOfSpecification": "Phenopacket v1"


### PR DESCRIPTION
Change the link for the individuals schema (was previously a not-very-useful link to phenopackets repo, change to beacon endpoint `/individual_schema`).