### PR TITLE
Features/overview endpoint

### DIFF
--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -83,7 +83,7 @@ def beacon_map():
     return beacon_info_response(current_app.config.get("BEACON_MAP", build_beacon_map()))
 
 
-# custom endpoint not in spec
+# custom endpoint not in beacon spec
 @info.route("/overview")
 @authz_middleware.deco_public_endpoint
 def beacon_overview():

--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -83,6 +83,14 @@ def beacon_map():
     return beacon_info_response(current_app.config.get("BEACON_MAP", build_beacon_map()))
 
 
+# custom endpoint not in spec
+@info.route("/overview")
+@authz_middleware.deco_public_endpoint
+def beacon_overview():
+    service_info = current_app.config.get("SERVICE_INFO", build_service_info())
+    return beacon_info_response({**service_info, "overview": overview()})
+
+
 # -------------------------------------------------------
 #  schemas
 # -------------------------------------------------------


### PR DESCRIPTION
Add an `/overview` endpoint. Currently we send overview information as part of the response from `/info`, but this endpoint is part of the beacon spec, so restricts the kinds of responses we can send.

For the moment /overview just gives the same response as /info, any changes to the response need to be done in tandem with the relevant code in bento_public that unpacks the response. 