### PR TITLE
Remove tables

### DIFF
--- a/bento_beacon/utils/gohan_utils.py
+++ b/bento_beacon/utils/gohan_utils.py
@@ -232,28 +232,10 @@ def gohan_counts_by_assembly_id():
 
 # only runs if "useGohan" true
 def gohan_counts_for_overview():
-    # gohan /variants/overview hangs when no variants table
-    # so check for tables before calling
-    tables_url = current_app.config["GOHAN_BASE_URL"] + "/tables?data-type=variant"
-    tables = None
+    # TODO: call gohan to see if elasticsearch down before calling gohan_counts_by_assembly_id()
+    # ... was previously possible with /tables, may need a fresh gohan endpoint
+    return gohan_counts_by_assembly_id()
 
-    try:
-        tables = gohan_network_call(tables_url, {})
-    except APIException:
-        # note this exception but don't rethrow
-        current_app.logger.error("cannot reach gohan for overview")
-    
-    # non-empty tables
-    if tables:
-        return gohan_counts_by_assembly_id()
-    
-    # empty tables (fresh instance or elasticsearch down)
-    # "useGohan" is true here so we expect variants to exist
-    if tables is not None:
-        return {"error": "no variants available"}
-
-    # else bad response from gohan
-    return {"error": "gohan unavailable"}
 
 # --------------------------------------------
 #     BEACON VARIANT QUERY TYPES

--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -21,7 +21,8 @@ def katsu_filters_query(beacon_filters, datatype, get_biosample_ids=False):
         return []
         # return {"count": 0, "results": []}
 
-    # possibly multiple tables tables, combine results
+    # possibly multiple projects/datasets, combine results
+    # TODO: revist when we clarify relationship between project and beacons
     for value in results.values():
         if value.get("data_type") == datatype:
             match_list = match_list + value.get("matches")


### PR DESCRIPTION
Remove references to Bento tables. 

Gohan `/tables` was used to verify that elasticsearch was up; when eleasticsearch is down, `/variants/overview` hangs for a very long time. (I don't see an immediate replacement endpoint to check, ideally it would be `/datasets`, but that returns nothing).
