### PR TITLE
Features/censorship failure mode

### DIFF
--- a/bento_beacon/app.py
+++ b/bento_beacon/app.py
@@ -79,18 +79,19 @@ with app.app_context():
             # katsu down or unavailable, details logged when exception thrown
             # swallow exception and continue retries
             current_app.logger.error("error calling katsu for censorship settings")
-        
+
         if max_filters is not None and count_threshold is not None:
             break
         sleep(5 + 5*tries)
 
     # either params retrieved or we hit max retries
     if max_filters is None or count_threshold is None:
-        # kill container
-        raise RuntimeError("unable to retrieve censorship settings from katsu")
+        current_app.logger.error("unable to retrieve censorship settings from katsu")
+    else:
+        current_app.logger.info(
+            f"retrieved censorship params: max_filter {max_filters}, count_threshold: {count_threshold}")
 
-    current_app.logger.info(
-        f"retrieved censorship params: max_filter {max_filters}, count_threshold: {count_threshold}")
+    # save even if None
     current_app.config["MAX_FILTERS"] = max_filters
     current_app.config["COUNT_THRESHOLD"] = count_threshold
 

--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -1,9 +1,13 @@
 from flask import current_app, g
 from .katsu_utils import search_summary_statistics, overview_statistics
+from .exceptions import APIException
 
 
 def get_censorship_threshold():
-    return current_app.config["COUNT_THRESHOLD"]
+    threshold = current_app.config["COUNT_THRESHOLD"]
+    if threshold is None:
+        raise APIException(message="unable to retrieve 'count_threshold' censorship parameter from katsu")
+    return threshold
 
 
 def zero_count_response():

--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -14,7 +14,7 @@ def katsu_filters_query(beacon_filters, datatype, get_biosample_ids=False):
     match_list = []
 
     if results is None:
-        raise APIException("error calling metadata service")
+        raise APIException(message="error calling metadata service")
 
     # response correct but nothing found
     if not results:


### PR DESCRIPTION
Handle missing censorship parameters (these are retrieved from katsu at beacon startup, but katsu may be down or missing censorship info):

- return http 500 for all beacon searches
- information endpoints such as `service-info` respond normally