### PR TITLE
pxf v1 -> v2

### DIFF
--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -80,10 +80,10 @@ class Config:
             "name": "Individual",
             "ontologyTermForThisType":  {"id": "NCIT:C25190", "label": "Person"},
             "defaultSchema": {
-                "id": "phenopacket-v1",
-                "name": "phenopacket v1",
+                "id": "phenopacket-v2",
+                "name": "phenopacket v2",
                         "referenceToSchemaDefinition": f"{BEACON_BASE_URL}/individual_schema",
-                        "schemaVersion": "v1.0.0"
+                        "schemaVersion": "v2.0.0"
             },
             "partOfSpecification": "Phenopacket v1"
         },


### PR DESCRIPTION
Change phenopackets schema reference to v2. Beacon's `/individual_schema` endpoint just re-transmits what it gets from katsu, so no actual schema changes are needed. 