### PR TITLE
fix: threshold is inclusive

### DIFF
--- a/bento_beacon/utils/censorship.py
+++ b/bento_beacon/utils/censorship.py
@@ -13,7 +13,7 @@ def get_censorship_threshold():
 
 def censored_count(count):
     t = get_censorship_threshold()
-    if count < t:
+    if count <= t:
         return 0
     return count
 


### PR DESCRIPTION
Bug fix: censorship threshold is supposed to be inclusive, but values equal to the threshold were passing through. 

Note that the threshold is correctly applied [elsewhere in the code](https://github.com/bento-platform/bento_beacon/blob/master/bento_beacon/utils/beacon_response.py#L20), so parts of the response were inconsistent. 