### PR TITLE
handle multiple response messages

### DIFF
--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -10,10 +10,14 @@ def init_response_data():
     g.response_data = {}
     g.response_info = {}
 
-
-# TODO: handle multiple messages
 def add_info_to_response(info):
-    g.response_info["message"] = info
+    add_message({"description": info, "level": "info"}) 
+
+
+def add_message(message_obj):
+    messages = g.response_info.get("messages", [])
+    messages.append(message_obj)
+    g.response_info["messages"] = messages
 
 
 def add_stats_to_response(ids):


### PR DESCRIPTION
Handle multiple messages in the response `info` field. (Redmine [#2040](https://206.12.92.46/issues/2040)). Currently only one message is possible, but more are coming, (eg Redmine [#1918](https://206.12.92.46/issues/1918)).

- this stamps all messages as "info" level 
- we could add more levels in the future (eg "warning", although this [may be handled by the spec](https://github.com/ga4gh-beacon/beacon-v2/pull/105) in the future) 
- errors have their own response format so don't need to appear here
