### PR TITLE
Features/threshold in response

### DIFF
--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -1,6 +1,6 @@
 from flask import current_app, g, request
 from .katsu_utils import search_summary_statistics, overview_statistics
-from .censorship import get_censorship_threshold, censored_count
+from .censorship import get_censorship_threshold, censored_count, no_results_censorship_message
 from .exceptions import InvalidQuery, APIException
 from ..constants import GRANULARITY_BOOLEAN, GRANULARITY_COUNT, GRANULARITY_RECORD
 
@@ -107,6 +107,8 @@ def build_query_response(ids=None, numTotalResults=None, full_record_handler=Non
     granularity = response_granularity()
     count = len(ids) if numTotalResults is None else numTotalResults
     returned_count = censored_count(count)
+    if returned_count == 0 and not g.permission_query_data:
+        add_info_to_response(no_results_censorship_message())
     if granularity == GRANULARITY_BOOLEAN:
         return beacon_boolean_response(returned_count)
     if granularity == GRANULARITY_COUNT:

--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -1,6 +1,6 @@
 from flask import current_app, g, request
 from .katsu_utils import search_summary_statistics, overview_statistics
-from .censorship import get_censorship_threshold, censored_count, no_results_censorship_message
+from .censorship import get_censorship_threshold, censored_count, MESSAGE_FOR_CENSORED_QUERY_WITH_NO_RESULTS
 from .exceptions import InvalidQuery, APIException
 from ..constants import GRANULARITY_BOOLEAN, GRANULARITY_COUNT, GRANULARITY_RECORD
 
@@ -19,6 +19,11 @@ def add_message(message_obj):
     messages = g.response_info.get("messages", [])
     messages.append(message_obj)
     g.response_info["messages"] = messages
+
+
+def add_no_results_censorship_message_to_response():
+    add_info_to_response(MESSAGE_FOR_CENSORED_QUERY_WITH_NO_RESULTS)
+    add_info_to_response(f"censorship threshold: {current_app.config['COUNT_THRESHOLD']}")
 
 
 def add_stats_to_response(ids):
@@ -109,7 +114,7 @@ def build_query_response(ids=None, numTotalResults=None, full_record_handler=Non
     count = len(ids) if numTotalResults is None else numTotalResults
     returned_count = censored_count(count)
     if returned_count == 0 and get_censorship_threshold() > 0:
-        add_info_to_response(no_results_censorship_message())
+        add_no_results_censorship_message_to_response()
     if granularity == GRANULARITY_BOOLEAN:
         return beacon_boolean_response(returned_count)
     if granularity == GRANULARITY_COUNT:

--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -108,7 +108,7 @@ def build_query_response(ids=None, numTotalResults=None, full_record_handler=Non
     granularity = response_granularity()
     count = len(ids) if numTotalResults is None else numTotalResults
     returned_count = censored_count(count)
-    if returned_count == 0 and not g.permission_query_data:
+    if returned_count == 0 and get_censorship_threshold() > 0:
         add_info_to_response(no_results_censorship_message())
     if granularity == GRANULARITY_BOOLEAN:
         return beacon_boolean_response(returned_count)

--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -10,6 +10,7 @@ def init_response_data():
     g.response_data = {}
     g.response_info = {}
 
+
 def add_info_to_response(info):
     add_message({"description": info, "level": "info"}) 
 

--- a/bento_beacon/utils/censorship.py
+++ b/bento_beacon/utils/censorship.py
@@ -2,11 +2,7 @@ from flask import current_app, g
 from .exceptions import APIException, InvalidQuery
 
 
-def no_results_censorship_message():
-    return (
-        "No results. Either none were found, or the query produced results numbering at "
-        f"or below the threshold for censorship ({current_app.config['COUNT_THRESHOLD']} items)"
-    )
+MESSAGE_FOR_CENSORED_QUERY_WITH_NO_RESULTS = "No results. Either none were found, or the query produced results numbering at or below the threshold for censorship."
 
 
 def get_censorship_threshold():

--- a/bento_beacon/utils/censorship.py
+++ b/bento_beacon/utils/censorship.py
@@ -2,6 +2,13 @@ from flask import current_app, g
 from .exceptions import APIException, InvalidQuery
 
 
+def no_results_censorship_message():
+    return (
+        "No results. Either none were found, or the query produced results numbering at "
+        f"or below the threshold for censorship ({current_app.config['COUNT_THRESHOLD']} items)"
+    )
+
+
 def get_censorship_threshold():
     if g.permission_query_data:
         return 0


### PR DESCRIPTION
Mention censorship threshold in beacon response. (Redmine [#1918](https://206.12.92.46/issues/1918))

A short message is added to all searches with no results. The same message is given whether censorship was applied or not (the true results may be zero, or some amount within the threshold for censorship that was then changed to zero). Mentioning it only when censorship is applied would be a data leak. 

Despite the text in the ticket, there is no point adding this message to all responses, this is just noise if results are above the threshold. It could be added to e.g. service-info if it needs to be advertised more broadly. 