### PR TITLE
Fixes/info responses

### DIFF
--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -213,16 +213,19 @@ def build_entry_types():
 
 
 def build_beacon_map():
-    beacon_map = {}
+    beacon_map = {
+        "$schema": current_app.config["INFO_ENDPOINTS_SCHEMAS"]["/map"]["schema"],
+        "endpointSets": {}
+    }
     endpoint_sets = current_app.config["BEACON_CONFIG"].get("endpointSets")
     for endpoint_set in endpoint_sets:
         resource_name = "g_variants" if endpoint_set == "variants" else endpoint_set
         root_url = current_app.config["BEACON_BASE_URL"] + "/" + resource_name
         entry_type = current_app.config["ENTRY_TYPES_DETAILS"].get(endpoint_set, {}).get("entryType")
-        beacon_map[entry_type] = {"rootUrl": root_url, "entryType": entry_type}
+        beacon_map["endpointSets"][entry_type] = {"rootUrl": root_url, "entryType": entry_type}
 
         if endpoint_set in ["datasets", "cohorts"]:
-            beacon_map[entry_type]["singleEntryUrl"] = root_url + "/{id}"
+            beacon_map["endpointSets"][entry_type]["singleEntryUrl"] = root_url + "/{id}"
 
     current_app.config["BEACON_MAP"] = beacon_map
     return beacon_map

--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -16,9 +16,6 @@ from ..utils.gohan_utils import gohan_counts_for_overview
 info = Blueprint("info", __name__)
 
 
-JSON_SCHEMA = "https://json-schema.org/draft/2020-12/schema"
-
-
 def overview():
     if current_app.config["BEACON_CONFIG"].get("useGohan"):
         variants_count = gohan_counts_for_overview()
@@ -184,7 +181,7 @@ def build_configuration_endpoint_response():
     production_status = current_app.config.get("SERVICE_DETAILS", build_service_details()).get("environment", "error").upper()
 
     response = {
-        "$schema": JSON_SCHEMA,
+        "$schema": current_app.config["INFO_ENDPOINTS_SCHEMAS"]["/configuration"]["schema"],
         "entryTypes": entry_types_details,
         "maturityAttributes": {"productionStatus": production_status}
     }

--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -1,5 +1,3 @@
-import json
-from copy import deepcopy
 from flask import Blueprint, current_app
 from ..authz.middleware import authz_middleware
 from ..utils.beacon_response import beacon_info_response

--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -72,7 +72,8 @@ def beacon_configuration():
 @info.route("/entry_types")
 @authz_middleware.deco_public_endpoint
 def entry_types():
-    return beacon_info_response(current_app.config.get("ENTRY_TYPES", build_entry_types()))
+    e_types = current_app.config.get("ENTRY_TYPES", build_entry_types())
+    return beacon_info_response({"entryTypes": e_types})
 
 
 @info.route("/map")
@@ -190,14 +191,14 @@ def build_configuration_endpoint_response():
 
 
 def build_entry_types():
-    entry_types_response = {}
+    entry_types = {}
     endpoint_sets = current_app.config["BEACON_CONFIG"].get("endpointSets")
     entry_types_details = current_app.config["ENTRY_TYPES_DETAILS"]
     for endpoint_set in endpoint_sets:
         entry = entry_types_details.get(endpoint_set)
         entry_type_name = entry.get("entryType")
 
-        entry_types_response[entry_type_name] = {
+        entry_types[entry_type_name] = {
             "id": entry_type_name,
             "name": entry.get("name"),
             "ontologyTermForThisType": entry.get("ontologyTermForThisType"),
@@ -205,8 +206,8 @@ def build_entry_types():
             "defaultSchema": entry.get("defaultSchema")
         }
 
-    current_app.config["ENTRY_TYPES"] = entry_types_response
-    return entry_types_response
+    current_app.config["ENTRY_TYPES"] = entry_types
+    return entry_types
 
 
 def build_beacon_map():


### PR DESCRIPTION
Fixes to info endpoints: 

- replace a few response fields that got clobbered in a refactor (eg `/entry_types` was missing the outer field "entryTypes")

- change use of $schema in `/configuration` (and add to `/map` response). This is an odd and ambiguous part of the beacon schema. What's expected here is a reference to the schema for the response being given (and not, eg, to a particular JSON schema dialect). It's not at all clear why this exists, since "returnedSchemas" is already a required field, and $schema isn't part of the response for any other endpoints.  