### PR TITLE
update vscode debug settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,10 +3,9 @@
     "configurations": [
         {
             "name": "Python: Attach Debugger (Bento)",
-            "type": "python",
+            "type": "debugpy",
             "request": "attach",
-            "port": 5683,
-            "host": "0.0.0.0"
+            "connect": { "host": "0.0.0.0", "port": 5683 },
         }
     ]
 }


### PR DESCRIPTION
Update VScode debug settings, `"type": "python"` being deprecated (annoyingly the host/port syntax is also different)