### PR TITLE
Re-attempt censorship settings on query

### DIFF
--- a/bento_beacon/app.py
+++ b/bento_beacon/app.py
@@ -17,6 +17,7 @@ from .utils.beacon_response import beacon_error_response
 from .utils.beacon_request import save_request_data, validate_request, verify_permissions
 from .utils.beacon_response import init_response_data
 from .utils.katsu_utils import katsu_censorship_settings
+from .utils.censorship import set_censorship_settings
 
 REQUEST_SPEC_RELATIVE_PATH = "beacon-v2/framework/json/requests/"
 BEACON_MODELS = ["analyses", "biosamples", "cohorts", "datasets", "individuals", "runs", "variants"]
@@ -92,8 +93,7 @@ with app.app_context():
             f"retrieved censorship params: max_filter {max_filters}, count_threshold: {count_threshold}")
 
     # save even if None
-    current_app.config["MAX_FILTERS"] = max_filters
-    current_app.config["COUNT_THRESHOLD"] = count_threshold
+    set_censorship_settings(max_filters, count_threshold)
 
 
 @app.before_request

--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -160,7 +160,7 @@ class Config:
         "schema": "phenopackets v1"
     }
 
-    MAX_RETRIES_FOR_CENSORSHIP_PARAMS = 5
+    MAX_RETRIES_FOR_CENSORSHIP_PARAMS = 2
 # -------------------
 # gohan
 

--- a/bento_beacon/utils/censorship.py
+++ b/bento_beacon/utils/censorship.py
@@ -16,7 +16,7 @@ def censorship_retry():
     max_filters, count_threshold = katsu_censorship_settings()
     if max_filters is None or count_threshold is None:
         raise APIException(message="error reading censorship settings from katsu: "
-                           + "max_filters: {max_filters}, count_threshold: {count_threshold}")
+                           + f"max_filters: {max_filters}, count_threshold: {count_threshold}")
 
     set_censorship_settings(max_filters, count_threshold)
     return max_filters, count_threshold

--- a/bento_beacon/utils/censorship.py
+++ b/bento_beacon/utils/censorship.py
@@ -12,7 +12,7 @@ def set_censorship_settings(max_filters, count_threshold):
 
 
 # saves settings to config as a side effect
-def censorship_retry():
+def censorship_retry() -> tuple[int | None, int | None]:
     max_filters, count_threshold = katsu_censorship_settings()
     if max_filters is None or count_threshold is None:
         raise APIException(message="error reading censorship settings from katsu: "
@@ -22,12 +22,12 @@ def censorship_retry():
     return max_filters, count_threshold
 
 
-def threshold_retry():
+def threshold_retry() -> int | None:
     _, count_threshold = censorship_retry()
     return count_threshold
 
 
-def max_filters_retry():
+def max_filters_retry() -> int | None:
     max_filters, _ = censorship_retry()
     return max_filters
 

--- a/bento_beacon/utils/censorship.py
+++ b/bento_beacon/utils/censorship.py
@@ -18,6 +18,8 @@ def censorship_retry() -> tuple[int | None, int | None]:
         raise APIException(message="error reading censorship settings from katsu: "
                            + f"max_filters: {max_filters}, count_threshold: {count_threshold}")
 
+    current_app.logger.info(
+        f"setting censorship parameters max_filters: {max_filters}, count_threshold: {count_threshold}")
     set_censorship_settings(max_filters, count_threshold)
     return max_filters, count_threshold
 

--- a/bento_beacon/utils/censorship.py
+++ b/bento_beacon/utils/censorship.py
@@ -1,17 +1,42 @@
 from flask import current_app, g
 from .exceptions import APIException, InvalidQuery
+from .katsu_utils import katsu_censorship_settings
 
 
 MESSAGE_FOR_CENSORED_QUERY_WITH_NO_RESULTS = "No results. Either none were found, or the query produced results numbering at or below the threshold for censorship."
+
+
+def set_censorship_settings(max_filters, count_threshold):
+    current_app.config["MAX_FILTERS"] = max_filters
+    current_app.config["COUNT_THRESHOLD"] = count_threshold
+
+
+# saves settings to config as a side effect
+def censorship_retry():
+    max_filters, count_threshold = katsu_censorship_settings()
+    if max_filters is None or count_threshold is None:
+        raise APIException(message="error reading censorship settings from katsu: "
+                           + "max_filters: {max_filters}, count_threshold: {count_threshold}")
+
+    set_censorship_settings(max_filters, count_threshold)
+    return max_filters, count_threshold
+
+
+def threshold_retry():
+    _, count_threshold = censorship_retry()
+    return count_threshold
+
+
+def max_filters_retry():
+    max_filters, _ = censorship_retry()
+    return max_filters
 
 
 def get_censorship_threshold():
     if g.permission_query_data:
         return 0
     threshold = current_app.config["COUNT_THRESHOLD"]
-    if threshold is None:
-        raise APIException(message="unable to retrieve 'count_threshold' censorship parameter from katsu")
-    return threshold
+    return threshold if threshold is not None else threshold_retry()
 
 
 def censored_count(count):
@@ -24,9 +49,7 @@ def censored_count(count):
 # we don't have the same option of returning zero here
 def get_max_filters():
     max_filters = current_app.config["MAX_FILTERS"]
-    if max_filters is None:
-        raise APIException(message="unable to retrieve 'max_query_parameters' censorship setting from katsu")
-    return max_filters
+    return max_filters if max_filters is not None else max_filters_retry()
 
 
 # ugly side-effect code, but keeps censorship code together


### PR DESCRIPTION
Adds code to re-attempt retrieving censorship settings from katsu. 

Beacon calls katsu at startup for censorship settings, but currently fails permanently after a set number of retries. This pr adds code to re-attempt retrieving censorship settings whenever a query is made, if censorship settings are missing. The number of retries at startup is also lowered. 

At some point we may decide that retrieving at startup is no longer necessary, and use the query-driven system only. 





