### PR TITLE
ignore dataset description if katsu down

### DIFF
--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -239,7 +239,11 @@ def katsu_total_individuals_count():
 def katsu_datasets(id=None):
     c = current_app.config
     endpoint = c["KATSU_DATASETS_ENDPOINT"]
-    response = katsu_get(endpoint, id, query="format=phenopackets")
+    try:
+        response = katsu_get(endpoint, id, query="format=phenopackets")
+    except APIException:
+        return {}
+
     if "detail" in response and response["detail"] == "Not found.":
         return {}
 


### PR DESCRIPTION
Corrects an issue where `/service-info` would return an invalid response when katsu is down (it would return an error response in beacon format, but that doesn't match the spec for service-info). Also allows the root endpoint `/` to return service details even when katsu is down, instead of an error response. 

Some info endpoints will still return errors when katsu is down (`/info`, `/overview` and others) but this is expected. 
