### PR TITLE
censor overview stats

### DIFF
--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -1,6 +1,6 @@
 from flask import current_app, g, request
 from .katsu_utils import search_summary_statistics, overview_statistics
-from .censorship import get_censorship_threshold, censored_count, MESSAGE_FOR_CENSORED_QUERY_WITH_NO_RESULTS
+from .censorship import get_censorship_threshold, censored_count, censored_chart_data, MESSAGE_FOR_CENSORED_QUERY_WITH_NO_RESULTS
 from .exceptions import InvalidQuery, APIException
 from ..constants import GRANULARITY_BOOLEAN, GRANULARITY_COUNT, GRANULARITY_RECORD
 
@@ -58,8 +58,8 @@ def package_biosample_and_experiment_stats(stats):
     experiment_type_data = [{"label": key, "value": value} for key, value in experiment_type.items()]
 
     return {
-        "biosamples": {"count": biosamples_count, "sampled_tissue": sampled_tissue_data},
-        "experiments": {"count": experiments_count, "experiment_type": experiment_type_data},
+        "biosamples": {"count": censored_count(biosamples_count), "sampled_tissue": censored_chart_data(sampled_tissue_data)},
+        "experiments": {"count": censored_count(experiments_count), "experiment_type": censored_chart_data(experiment_type_data)},
     }
 
 

--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -1,6 +1,11 @@
 from flask import current_app, g, request
 from .katsu_utils import search_summary_statistics, overview_statistics
-from .censorship import get_censorship_threshold, censored_count, censored_chart_data, MESSAGE_FOR_CENSORED_QUERY_WITH_NO_RESULTS
+from .censorship import (
+    get_censorship_threshold,
+    censored_count,
+    censored_chart_data,
+    MESSAGE_FOR_CENSORED_QUERY_WITH_NO_RESULTS,
+)
 from .exceptions import InvalidQuery, APIException
 from ..constants import GRANULARITY_BOOLEAN, GRANULARITY_COUNT, GRANULARITY_RECORD
 
@@ -58,8 +63,14 @@ def package_biosample_and_experiment_stats(stats):
     experiment_type_data = [{"label": key, "value": value} for key, value in experiment_type.items()]
 
     return {
-        "biosamples": {"count": censored_count(biosamples_count), "sampled_tissue": censored_chart_data(sampled_tissue_data)},
-        "experiments": {"count": censored_count(experiments_count), "experiment_type": censored_chart_data(experiment_type_data)},
+        "biosamples": {
+            "count": censored_count(biosamples_count),
+            "sampled_tissue": censored_chart_data(sampled_tissue_data),
+        },
+        "experiments": {
+            "count": censored_count(experiments_count),
+            "experiment_type": censored_chart_data(experiment_type_data),
+        },
     }
 
 

--- a/bento_beacon/utils/censorship.py
+++ b/bento_beacon/utils/censorship.py
@@ -66,7 +66,7 @@ def reject_if_too_many_filters(filters):
         raise InvalidQuery(f"too many filters in request, maximum of {max_filters} permitted")
 
 
-# at some point may want to show fields as zero rather than removing entirely
+# at some point may want to show censored fields as zero rather than removing entirely
 def censored_chart_data(data):
     t = get_censorship_threshold()  # zero with correct permissions
     return [{"label": d["label"], "value": d["value"]} for d in data if d["value"] > t]

--- a/bento_beacon/utils/censorship.py
+++ b/bento_beacon/utils/censorship.py
@@ -64,3 +64,8 @@ def reject_if_too_many_filters(filters):
     max_filters = get_max_filters()
     if len(filters) > max_filters:
         raise InvalidQuery(f"too many filters in request, maximum of {max_filters} permitted")
+
+
+def censored_chart_data(data):
+    t = get_censorship_threshold()  # zero with correct permissions
+    return [{"label": d["label"], "value": d["value"]} for d in data if d["value"] > t]

--- a/bento_beacon/utils/censorship.py
+++ b/bento_beacon/utils/censorship.py
@@ -66,6 +66,7 @@ def reject_if_too_many_filters(filters):
         raise InvalidQuery(f"too many filters in request, maximum of {max_filters} permitted")
 
 
+# at some point may want to show fields as zero rather than removing entirely
 def censored_chart_data(data):
     t = get_censorship_threshold()  # zero with correct permissions
     return [{"label": d["label"], "value": d["value"]} for d in data if d["value"] > t]


### PR DESCRIPTION
Apply censorship to search overview statistics (counts and chart details for biosamples and experiments):
- any count at or below the threshold is rounded to zero
- any chart segments at or below the threshold are removed from the chart. This matches the behaviour elsewhere in the app. If we ever start using bar charts in search summaries we may want to start showing fields as zero rather than removing. Currently we use pies only. 

Search statistics are an internal Bento feature only, so I didn't add a warning message in the response about censorship. This is probably best done in the UI. 

