### PR TITLE
first pass at creating filtering terms from katsu public config

### DIFF
--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -48,11 +48,9 @@ def beacon_info_with_overview():
 
 @info.route("/filtering_terms")
 @authz_middleware.deco_public_endpoint
-# TODO
 def filtering_terms():
-    resources = get_filtering_term_resources()
     filtering_terms = get_filtering_terms()
-    return beacon_info_response({"resources": resources, "filteringTerms": filtering_terms})
+    return beacon_info_response({"resources": [], "filteringTerms": filtering_terms})
 
 
 # distinct from "BEACON_CONFIG"

--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -3,7 +3,6 @@ from ..authz.middleware import authz_middleware
 from ..utils.beacon_response import beacon_info_response
 from ..utils.katsu_utils import (
     get_filtering_terms,
-    get_filtering_term_resources,
     katsu_total_individuals_count,
     katsu_get,
     katsu_datasets,

--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -221,7 +221,7 @@ def get_filtering_terms():
             "type": "alphanumeric",
             "id": f["id"],
             "label": f["title"],
-            "options": f["options"],  # unimplemented proposal: https://github.com/ga4gh-beacon/beacon-v2/issues/79
+            "values": f["options"],  # unimplemented proposal: https://github.com/ga4gh-beacon/beacon-v2/pull/160,
             "description": f.get("description", ""),
             # "modelPath": f["mapping"] unimplemented proposal: https://github.com/ga4gh-beacon/beacon-v2/issues/115
             # proposal is for path in beacon spec, so our mapping does not match exactly

--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -204,34 +204,43 @@ def katsu_resources_to_beacon_resource(r):
     return {key: value for (key, value) in r.items() if key != "created" and key != "updated"}
 
 
-# filtering terms for katsu public config search only
-# possible TODOs:
-#  - ontology term filters (needs better ontology support)
-#  - filters for general phenopacket / experiment search
-#  - memoize?
-def get_filtering_terms():
-    fields_nested = get_katsu_config_search_fields().get("sections", [])
-    fields = []
-    for f in fields_nested:
-        fields.extend(f["fields"])
-
+def katsu_config_filtering_terms():
     filtering_terms = []
-    for f in fields:
-        filtering_term = {
-            "type": "alphanumeric",
-            "id": f["id"],
-            "label": f["title"],
-            "values": f["options"],  # unimplemented proposal: https://github.com/ga4gh-beacon/beacon-v2/pull/160,
-            "description": f.get("description", ""),
-            # "modelPath": f["mapping"] unimplemented proposal: https://github.com/ga4gh-beacon/beacon-v2/issues/115
-            # proposal is for path in beacon spec, so our mapping does not match exactly
-            #
-            # "scopes": scope for us is always all queryable entities in this beacon, but that can vary per beacon
-            # we can infer this from the endpoints / blueprints that are active
-        }
-        filtering_terms.append(filtering_term)
+    sections = get_katsu_config_search_fields().get("sections", [])
+    for section in sections:
+        for field in section["fields"]:
+            filtering_term = {
+                "type": "alphanumeric",
+                "id": field["id"],
+                "label": field["title"],
+                # longer lablel / helptext
+                "description": field.get("description", ""),
+                #
+                # bento internal use fields, more to come
+                "bento": {"section": section["section_title"]},
+                #
+                # unimplemented proposal: https://github.com/ga4gh-beacon/beacon-v2/pull/160
+                # optionally move to "bento" field if never adopted
+                "values": field["options"],
+                #
+                # another unimplemented proposal: https://github.com/ga4gh-beacon/beacon-v2/issues/115
+                # proposal is for path in beacon spec, so our mapping does not match exactly
+                # "target": f["mapping"]
+                #
+                # TODO: scopes
+                # filter scope for us is always all queryable entities in this beacon, but that can vary per beacon
+                # we can infer this from the endpoints / blueprints that are active
+            }
+            filtering_terms.append(filtering_term)
 
     return filtering_terms
+
+
+#  memoize?
+def get_filtering_terms():
+    # add ontology filters here when we start supporting ontologies
+    # could also add filters for phenopacket and experiment queries
+    return katsu_config_filtering_terms()
 
 
 # -------------------------------------------------------

--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -213,6 +213,7 @@ def katsu_config_filtering_terms():
                 "type": "alphanumeric",
                 "id": field["id"],
                 "label": field["title"],
+                #
                 # longer lablel / helptext
                 "description": field.get("description", ""),
                 #
@@ -229,7 +230,7 @@ def katsu_config_filtering_terms():
                 #
                 # TODO: scopes
                 # filter scope for us is always all queryable entities in this beacon, but that can vary per beacon
-                # we can infer this from the endpoints / blueprints that are active
+                # we can infer this from the queryable endpoints / blueprints that are active
             }
             filtering_terms.append(filtering_term)
 


### PR DESCRIPTION
First pass at creating beacon filtering terms from katsu public config (Redmine #1578, #2193)

- Needed to (eventually) drive beacon UI from beacon backend; currently the UI still calls katsu on its own, with beacon left not knowing about its own filter options. 
- Helpful for beacon network 
- uses "values" list proposed for beacon spec, although can be used even if not adopted.

May need tweaks for use with scoped discovery config.