### PR TITLE
handle variants queries gracefully when not using gohan

### DIFF
--- a/bento_beacon/utils/search.py
+++ b/bento_beacon/utils/search.py
@@ -1,6 +1,8 @@
+from flask import current_app
 from functools import reduce
 from .gohan_utils import query_gohan
 from .katsu_utils import katsu_filters_query, search_from_config, biosample_ids_for_individuals
+from .beacon_response import add_info_to_response
 
 
 # TODO: search by linked field set elements instead of hardcoding
@@ -11,6 +13,10 @@ def biosample_id_search(variants_query=None, phenopacket_filters=None, experimen
         return []
 
     if variants_query:
+        if not current_app.config["BEACON_CONFIG"].get("useGohan"):
+            # variants query even though there are no variants in this beacon, this can happen in a network context
+            add_info_to_response("No variants available at this beacon, query by metadata values only")
+            return []
         variant_sample_ids = query_gohan(variants_query, "count", ids_only=True)
         if not variant_sample_ids:
             return []


### PR DESCRIPTION
(Redmine #2190)


Some Bento instances do not have variants data, and if they have a beacon UI, the variants portion of the UI is turned off. A variants query to any of these beacons is interpreted as an error, since it suggests a misconfigured UI.

However in the context of a beacon network, it should be considered normal to receive requests about variants when none are available.  This pr replaces the previous error response with a zero results response, along with a short message.


