### PR TITLE
all default handling for optional field welcomeUrl

### DIFF
--- a/bento_beacon/endpoints/info.py
+++ b/bento_beacon/endpoints/info.py
@@ -146,7 +146,7 @@ def build_ga4gh_service_info():
         "name": info["name"],
         "type": {"artifact": "Beacon v2", "group": "org.ga4gh", "version": info["apiVersion"]},
         "environment": info["environment"],
-        "organization": {"name": info["organization"]["name"], "url": info["organization"]["welcomeUrl"]},
+        "organization": {"name": info["organization"]["name"], "url": info["organization"].get("welcomeUrl", "")},
         "contactUrl": info["organization"]["contactUrl"],
         "version": info["version"],
         "bento": {"serviceKind": "beacon"},


### PR DESCRIPTION
Required service-info field `organization.url` was pulled from optional beacon info field `organization.welcomeUrl`, so add default handling for where this happens to be missing.

(Redmine #2252)