### PR TITLE
add gene ID search

### DIFF
--- a/bento_beacon/config_files/config.py
+++ b/bento_beacon/config_files/config.py
@@ -172,6 +172,7 @@ class Config:
 
     # don't let anonymous users query arbitrary phenopacket or experiment fields
     ANONYMOUS_METADATA_QUERY_USES_DISCOVERY_CONFIG_ONLY = True
+
     # -------------------
     # gohan
 
@@ -185,6 +186,10 @@ class Config:
     # drs
 
     DRS_URL = os.environ.get("DRS_URL")
+
+    # -------------------
+    # reference
+    REFERENCE_URL = os.environ.get("REFERENCE_URL")
 
     # -------------------
     # authorization

--- a/bento_beacon/utils/gohan_utils.py
+++ b/bento_beacon/utils/gohan_utils.py
@@ -144,6 +144,7 @@ def geneId_query_to_gohan(beacon_args, granularity, ids_only):
     gohan_args = beacon_to_gohan_generic_mapping(beacon_args)
 
     gohan_results = []
+    # TODO: async
     for assembly in assemblies:
         gene_info = gene_position_lookup(gene_id, assembly)
         if not gene_info:

--- a/bento_beacon/utils/gohan_utils.py
+++ b/bento_beacon/utils/gohan_utils.py
@@ -1,5 +1,5 @@
-from flask import current_app
 import requests
+from flask import current_app
 from .exceptions import APIException, InvalidQuery, NotImplemented
 from ..authz.access import create_access_header_or_fall_back
 from .reference import gene_position_lookup

--- a/bento_beacon/utils/gohan_utils.py
+++ b/bento_beacon/utils/gohan_utils.py
@@ -141,6 +141,7 @@ def geneId_query_to_gohan(beacon_args, granularity, ids_only):
 
     # query all assemblies present in gohan if not specified
     assemblies = [assembly_from_query] if assembly_from_query is not None else gohan_assemblies()
+    gohan_args = beacon_to_gohan_generic_mapping(beacon_args)
 
     gohan_results = []
     for assembly in assemblies:
@@ -148,7 +149,8 @@ def geneId_query_to_gohan(beacon_args, granularity, ids_only):
         if not gene_info:
             continue
 
-        gohan_args = {
+        gohan_args_this_query = {
+            **gohan_args,
             "assemblyId": assembly,
             "chromosome": gene_info.get("chromosome"),
             "lowerBound": gene_info.get("start"),
@@ -156,7 +158,7 @@ def geneId_query_to_gohan(beacon_args, granularity, ids_only):
             "getSampleIdsOnly": ids_only,
         }
 
-        gohan_results.extend(generic_gohan_query(gohan_args, granularity, ids_only))
+        gohan_results.extend(generic_gohan_query(gohan_args_this_query, granularity, ids_only))
 
     return gohan_results
 

--- a/bento_beacon/utils/reference.py
+++ b/bento_beacon/utils/reference.py
@@ -5,8 +5,8 @@ from ..authz.access import create_access_header_or_fall_back
 import requests
 
 
-def gene_position_lookup(geneId: str, assemblyId: str) -> dict[str, str | int | None]:
-    reference_url = current_app.config["REFERENCE_URL"] + f"/genomes/{assemblyId}/features?name={geneId}"
+def gene_position_lookup(gene_id: str, assembly_id: str) -> dict[str, str | int | None]:
+    reference_url = current_app.config["REFERENCE_URL"] + f"/genomes/{assembly_id}/features?name={gene_id}"
     try:
         r = requests.get(
             reference_url,

--- a/bento_beacon/utils/reference.py
+++ b/bento_beacon/utils/reference.py
@@ -1,8 +1,8 @@
+import requests
 from json import JSONDecodeError
 from flask import current_app
 from .exceptions import APIException
 from ..authz.access import create_access_header_or_fall_back
-import requests
 
 
 def gene_position_lookup(gene_id: str, assembly_id: str) -> dict[str, str | int | None]:

--- a/bento_beacon/utils/reference.py
+++ b/bento_beacon/utils/reference.py
@@ -1,0 +1,33 @@
+from json import JSONDecodeError
+from flask import current_app
+from .exceptions import APIException
+from ..authz.access import create_access_header_or_fall_back
+import requests
+
+
+def gene_position_lookup(geneId, assemblyId) -> dict[str, str | int | None]:
+    reference_url = current_app.config["REFERENCE_URL"] + f"/genomes/{assemblyId}/features?name={geneId}"
+    try:
+        r = requests.get(
+            reference_url,
+            headers=create_access_header_or_fall_back(),
+            verify=current_app.config["BENTO_VALIDATE_SSL"],
+        )
+
+        results = r.json().get("results")
+        if not results:
+            return {}
+
+        chromosome = results[0].get("contig_name", "").removeprefix("chr")
+        entries = results[0].get("entries")
+        start = entries[0].get("start_pos") if entries else None
+        end = entries[0].get("end_pos") if entries else None
+
+    except JSONDecodeError:
+        current_app.logger.error(f"error reading response from reference service")
+        raise APIException(message="invalid non-JSON response from katsu")
+    except requests.exceptions.RequestException as e:
+        current_app.logger.error(f"reference service error: {e}")
+        raise APIException(message="error calling reference service")
+
+    return {"chromosome": chromosome, "start": start, "end": end}


### PR DESCRIPTION
First pass at gene ID search (see [beacon docs](https://docs.genomebeacons.org/variant-queries/#beacon-geneid-queries))

- allows variant search by gene symbol instead of explicit coordinates
- searches over all assemblies present in gohan if no assembly ID specified (mostly interesting for beacon network)
- should also work for non-gene features, although query parameter will still be called `geneId`

Requires Bento pr [#278](https://github.com/bento-platform/bento/pull/278)
