### PR TITLE
chore: set dummy version in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bento_beacon"
-version = "0.17.0"
+version = "0.0.0" # version is managed outside of Poetry for Beacon
 description = "GA4GH Beacon v2 microservice for the Bento platform"
 authors = ["Gordon Krieger <gordon.krieger@mcgill.ca>"]
 license = "LGPL-3.0-only"


### PR DESCRIPTION
Since the pyproject version field isn't used for beacon, keep it at `0.0.0` so it's not confusingly out of date.