### PR TITLE
fix deprecated aiohttp param

### DIFF
--- a/bento_beacon/utils/http.py
+++ b/bento_beacon/utils/http.py
@@ -2,7 +2,7 @@ import aiohttp
 
 
 def tcp_connector(c):
-    return aiohttp.TCPConnector(verify_ssl=not c["BENTO_DEBUG"])
+    return aiohttp.TCPConnector(ssl=not c["BENTO_DEBUG"])
 
 
 # aiohttp refuses to encode bools


### PR DESCRIPTION
Replace deprecated aiohttp`verify_ssl` parameter. 

Some discussion [here](https://github.com/aio-libs/aiohttp/issues/2626), and in the [3.0.0 changelog](https://docs.aiohttp.org/en/stable/changes.html#id782). 