### PR TITLE
katsu url fix for older network beacons

### DIFF
--- a/bento_beacon/network/utils.py
+++ b/bento_beacon/network/utils.py
@@ -191,8 +191,8 @@ async def init_network_service_registry():
 # Temp utils for bento public search terms
 
 
-def is_pr_build(url):
-    return url.startswith("pr-")
+def is_pr_build(version_string):
+    return version_string.startswith("pr-")
 
 
 def is_below_bento_beacon_version_19(beacon):

--- a/bento_beacon/network/utils.py
+++ b/bento_beacon/network/utils.py
@@ -195,6 +195,14 @@ def is_pr_build(url):
     return url.startswith("pr-")
 
 
+def is_below_bento_beacon_version_19(beacon):
+    version_string = beacon["version"]
+    # pr version names break version parsing but are assumed to be recent
+    if is_pr_build(version_string):
+        return False
+    return Version(version_string) < BEACON_VERSION_ZERO_POINT_NINETEEN
+
+
 # to deprecate
 async def get_public_search_fields(beacon):
     fields_url = public_search_fields_url(beacon)
@@ -205,17 +213,10 @@ async def get_public_search_fields(beacon):
 
 # to deprecate
 def public_search_fields_url(beacon):
-    split_url = urlsplit(beacon["apiUrl"])
-    version_string = beacon["version"]
-
     # fix for katsu url change in Bento 18
-    # pr version names break version parsing but are assumed to be recent
-    url_prefix = (
-        ""
-        if is_pr_build(version_string) or Version(version_string) >= BEACON_VERSION_ZERO_POINT_NINETEEN
-        else "portal."
-    )
+    url_prefix = "portal." if is_below_bento_beacon_version_19(beacon) else ""
 
+    split_url = urlsplit(beacon["apiUrl"])
     return urlunsplit((split_url.scheme, url_prefix + split_url.netloc, PUBLIC_SEARCH_FIELDS_PATH, "", ""))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def beacon_test_app():
             "CONFIG_ABSOLUTE_PATH": str(mock_config_files_dir),
             "BENTOV2_DOMAIN": "test.local",
             "BENTOV2_PUBLIC_URL": "http://test.local",
-            "BEACON_BASE_URL": "http://test.local/api/beacon",
+            "BEACON_BASE_URL": "https://test.local/api/beacon",
             "BENTO_BEACON_VERSION": "test",
             "KATSU_BASE_URL": KATSU_URL,
             "BEACON_KATSU_TIMEOUT": "1",

--- a/tests/data/beacon_network_config.json
+++ b/tests/data/beacon_network_config.json
@@ -1,7 +1,9 @@
 {
     "beacons": [
         "https://test.local/api/beacon",
-        "https://fake2.bento.local/api/beacon"
+        "https://fake1.bento.ca/api/beacon",
+        "https://fake2.bento.ca/api/beacon",
+        "https://fake-patched.bento.ca/api/beacon"
     ],
     "network_default_timeout_seconds": 30,
     "network_variants_query_timeout_seconds": 120

--- a/tests/data/service_responses.py
+++ b/tests/data/service_responses.py
@@ -2492,7 +2492,7 @@ pr_patch_tag = "pr-123"
 pr_patch_beacon_id = "ca.fake-patched.bento.beacon"
 
 network_beacon_overview_bento_18_with_pr_build = deepcopy(network_beacon_overview_bento_18)
-network_beacon_overview_bento_18_with_pr_build["version"] = pr_patch_tag
+network_beacon_overview_bento_18_with_pr_build["response"]["version"] = pr_patch_tag
 network_beacon_overview_bento_18_with_pr_build["meta"]["beaconId"] = pr_patch_beacon_id
 network_beacon_overview_bento_18_with_pr_build["response"]["id"] = pr_patch_beacon_id
 

--- a/tests/data/service_responses.py
+++ b/tests/data/service_responses.py
@@ -2497,5 +2497,4 @@ network_beacon_overview_bento_18_with_pr_build["meta"]["beaconId"] = pr_patch_be
 network_beacon_overview_bento_18_with_pr_build["response"]["id"] = pr_patch_beacon_id
 
 network_beacon_query_response_bento_18_with_pr_build = deepcopy(network_beacon_query_response_bento_18)
-network_beacon_overview_bento_18_with_pr_build["meta"]["beaconId"] = pr_patch_beacon_id
-network_beacon_overview_bento_18_with_pr_build["response"]["id"] = pr_patch_beacon_id
+network_beacon_query_response_bento_18_with_pr_build["meta"]["beaconId"] = pr_patch_beacon_id

--- a/tests/data/service_responses.py
+++ b/tests/data/service_responses.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 katsu_projects_response = {
     "count": 2,
     "next": None,
@@ -2316,3 +2318,184 @@ token_response = {
     "not-before-policy": 0,
     "scope": "profile email",
 }
+
+
+network_beacon_overview_bento_17 = {
+    "meta": {"apiVersion": "v2.0.0", "beaconId": "ca.fake1.bento.beacon", "returnedSchemas": [{}]},
+    "response": {
+        "apiVersion": "v2.0.0",
+        "description": "this is a beacon",
+        "environment": "prod",
+        "id": "ca.fake1.bento.beacon",
+        "name": "Fake Beacon",
+        "organization": {
+            "contactUrl": "https://computationalgenomics.ca/contact-us/",
+            "id": "local",
+            "logoUrl": "https://bentov2.local/public/assets/icon_small.png",
+            "name": "Local Beacon",
+            "welcomeUrl": "https://computationalgenomics.ca/",
+        },
+        "overview": {
+            "biosamples": {
+                "count": 4881,
+                "sampled_tissue": [
+                    {"label": "blood", "value": 2522},
+                    {"label": "Plasma", "value": 451},
+                    {"label": "Serum", "value": 1005},
+                ],
+            },
+            "counts": {"individuals": 2624, "variants": {"GRCh37": 24765426, "GRCh38": 27530622, "GRCm38": 14070}},
+            "experiments": {
+                "count": 4058,
+                "experiment_type": [
+                    {"label": "Metabolite profiling", "value": 152},
+                    {"label": "Neutralizing antibody titers", "value": 381},
+                    {"label": "Other", "value": 237},
+                    {"label": "Proteomic profiling", "value": 472},
+                    {"label": "RNA-Seq", "value": 294},
+                    {"label": "WGS", "value": 2522},
+                ],
+            },
+            "individuals": {"count": 2624},
+            "variants": {"GRCh37": 24765426, "GRCh38": 27530622, "GRCm38": 14070},
+        },
+        "version": "0.17.0",
+        "welcomeUrl": "https://fake1.bento.local/beacon_ui",
+    },
+}
+
+network_beacon_overview_bento_18 = {
+    "meta": {"apiVersion": "v2.0.0", "beaconId": "ca.fake2.bento.beacon", "returnedSchemas": [{}]},
+    "response": {
+        "apiVersion": "v2.0.0",
+        "description": "this is a beacon",
+        "environment": "dev",
+        "id": "ca.fake2.bento.beacon",
+        "name": "Another Fake Beacon",
+        "organization": {
+            "contactUrl": "https://genomics.example.com",
+            "id": "local",
+            "logoUrl": "https://bentov2.local/public/assets/icon_small.png",
+            "name": "Local Beacon",
+            "welcomeUrl": "https://genomics.example.com/welcome",
+        },
+        "overview": {
+            "biosamples": {
+                "count": 4881,
+                "sampled_tissue": [
+                    {"label": "blood", "value": 2522},
+                    {"label": "Plasma", "value": 451},
+                    {"label": "Serum", "value": 1005},
+                ],
+            },
+            "counts": {"individuals": 2624, "variants": {"GRCh37": 24765426, "GRCh38": 27530622, "GRCm38": 14070}},
+            "experiments": {
+                "count": 4058,
+                "experiment_type": [
+                    {"label": "Metabolite profiling", "value": 152},
+                    {"label": "Neutralizing antibody titers", "value": 381},
+                    {"label": "Other", "value": 237},
+                    {"label": "Proteomic profiling", "value": 472},
+                    {"label": "RNA-Seq", "value": 294},
+                    {"label": "WGS", "value": 2522},
+                ],
+            },
+            "individuals": {"count": 2624},
+            "variants": {"GRCh37": 24765426, "GRCh38": 27530622, "GRCm38": 14070},
+        },
+        # Bento 18 == beacon 0.19.0
+        "version": "0.19.0",
+        "welcomeUrl": "https://fake2.bento.local/beacon_ui",
+    },
+}
+
+network_beacon_query_response_bento_17 = {
+    "info": {
+        "bento": {
+            "biosamples": {
+                "count": 4881,
+                "sampled_tissue": [
+                    {"label": "blood", "value": 2522},
+                    {"label": "Plasma", "value": 451},
+                    {"label": "Serum", "value": 1005},
+                ],
+            },
+            "experiments": {
+                "count": 199,
+                "experiment_type": [{"label": "RNA-Seq", "value": 64}, {"label": "WES", "value": 135}],
+            },
+        },
+        "messages": [{"description": "no query found, returning total count", "level": "info"}],
+    },
+    "meta": {
+        "apiVersion": "v2.0.0",
+        "beaconId": "ca.fake1.bento.beacon",
+        "receivedRequestSummary": {
+            "apiVersion": "2.0.0",
+            "bento": {"showSummaryStatistics": True},
+            "pagination": {"limit": 10, "skip": 0},
+            "requestParameters": {"g_variant": {}},
+            "requestedGranularity": "count",
+            "requestedSchemas": [],
+        },
+        "returnedGranularity": "count",
+        "returnedSchemas": [],
+    },
+    "responseSummary": {"exists": True, "numTotalResults": 511},
+}
+
+
+network_beacon_query_response_bento_18 = {
+    "info": {
+        "bento": {
+            "biosamples": {
+                "count": 4881,
+                "sampled_tissue": [
+                    {"label": "blood", "value": 2522},
+                    {"label": "Plasma", "value": 451},
+                    {"label": "Serum", "value": 1005},
+                ],
+            },
+            "experiments": {
+                "count": 4058,
+                "experiment_type": [
+                    {"label": "Metabolite profiling", "value": 152},
+                    {"label": "Neutralizing antibody titers", "value": 381},
+                    {"label": "Other", "value": 237},
+                    {"label": "Proteomic profiling", "value": 472},
+                    {"label": "RNA-Seq", "value": 294},
+                    {"label": "WGS", "value": 2522},
+                ],
+            },
+            "individuals": {"count": 2624},
+        },
+        "messages": [{"description": "no query found, returning total count", "level": "info"}],
+    },
+    "meta": {
+        "apiVersion": "v2.0.0",
+        "beaconId": "ca.fake2.bento.beacon",
+        "receivedRequestSummary": {
+            "apiVersion": "2.0.0",
+            "bento": {"showSummaryStatistics": True},
+            "pagination": {"limit": 10, "skip": 0},
+            "requestedGranularity": "count",
+            "requestedSchemas": [],
+        },
+        "returnedGranularity": "count",
+        "returnedSchemas": [],
+    },
+    "responseSummary": {"exists": True, "numTotalResults": 2624},
+}
+
+
+pr_patch_tag = "pr-123"
+pr_patch_beacon_id = "ca.fake-patched.bento.beacon"
+
+network_beacon_overview_bento_18_with_pr_build = deepcopy(network_beacon_overview_bento_18)
+network_beacon_overview_bento_18_with_pr_build["version"] = pr_patch_tag
+network_beacon_overview_bento_18_with_pr_build["meta"]["beaconId"] = pr_patch_beacon_id
+network_beacon_overview_bento_18_with_pr_build["response"]["id"] = pr_patch_beacon_id
+
+network_beacon_query_response_bento_18_with_pr_build = deepcopy(network_beacon_query_response_bento_18)
+network_beacon_overview_bento_18_with_pr_build["meta"]["beaconId"] = pr_patch_beacon_id
+network_beacon_overview_bento_18_with_pr_build["response"]["id"] = pr_patch_beacon_id

--- a/tests/test_beacon_network.py
+++ b/tests/test_beacon_network.py
@@ -1,0 +1,99 @@
+from .test_routes import (
+    mock_permissions_none,
+    mock_katsu_public_rules,
+    mock_katsu_projects,
+    mock_gohan_overview,
+    mock_katsu_individuals,
+    mock_katsu_public_search_fields,
+    mock_katsu_public_search_query,
+    mock_katsu_public_search_no_query,
+    mock_katsu_private_search_query,
+    mock_katsu_private_search_overview,
+    mock_gohan_query,
+)
+from .data.service_responses import (
+    network_beacon_overview_bento_17,
+    network_beacon_overview_bento_18,
+    network_beacon_query_response_bento_17,
+    network_beacon_query_response_bento_18,
+    katsu_config_search_fields_response,
+    network_beacon_overview_bento_18_with_pr_build,
+)
+
+
+def mock_network_beacon_bento_17_overview(aioresponse):
+    url = "https://fake1.bento.ca/api/beacon/overview"
+    aioresponse.get(url, payload=network_beacon_overview_bento_17)
+
+
+def mock_network_beacon_bento_18_overview(aioresponse):
+    url = "https://fake2.bento.ca/api/beacon/overview"
+    aioresponse.get(url, payload=network_beacon_overview_bento_18)
+
+
+def mock_network_beacon_bento_18_overview_from_pr_build(aioresponse):
+    url = "https://fake-patched.bento.ca/api/beacon/overview"
+    aioresponse.get(url, payload=network_beacon_overview_bento_18_with_pr_build)
+
+
+def mock_network_beacon_bento_17_query_response(aioresponse):
+    url = "https://fake1.bento.ca/api/beacon/individuals"
+    aioresponse.post(url, payload=network_beacon_query_response_bento_17)
+
+
+def mock_network_beacon_bento_18_query_response(aioresponse):
+    url = "https://fake2.bento.ca/api/beacon/individuals"
+    aioresponse.post(url, payload=network_beacon_query_response_bento_18)
+
+
+def mock_network_beacon_bento_18_query_response_from_pr_build(aioresponse):
+    url = "https://fake-patched.bento.ca/api/beacon/individuals"
+    aioresponse.post(url, payload=network_beacon_query_response_bento_18)
+
+
+def mock_network_katsu_public_fields_response_bento_17(aioresponse):
+    url = "https://portal.fake1.bento.ca/api/metadata/api/public_search_fields"
+    aioresponse.get(url, payload=katsu_config_search_fields_response)
+
+
+def mock_network_katsu_public_fields_response_bento_18(aioresponse):
+    url = "https://fake2.bento.ca/api/metadata/api/public_search_fields"
+    aioresponse.get(url, payload=katsu_config_search_fields_response)
+
+
+def mock_network_katsu_public_fields_response_bento_18_from_pr_build(aioresponse):
+    url = "https://fake-patched.bento.ca/api/metadata/api/public_search_fields"
+    aioresponse.get(url, payload=katsu_config_search_fields_response)
+
+
+def test_network_endpoint(app_config, client, aioresponse):
+    mock_permissions_none(app_config, aioresponse)
+
+    # calls to network beacons
+    mock_network_beacon_bento_17_overview(aioresponse)
+    mock_network_beacon_bento_18_overview(aioresponse)
+    mock_network_beacon_bento_18_overview_from_pr_build(aioresponse)
+    mock_network_beacon_bento_17_query_response(aioresponse)
+    mock_network_beacon_bento_18_query_response(aioresponse)
+    mock_network_beacon_bento_18_query_response_from_pr_build(aioresponse)
+
+    # calls to network katsus
+    mock_network_katsu_public_fields_response_bento_17(aioresponse)
+    mock_network_katsu_public_fields_response_bento_18(aioresponse)
+    mock_network_katsu_public_fields_response_bento_18_from_pr_build(aioresponse)
+
+    # calls for local beacon hosting the network
+    mock_katsu_public_rules(app_config, aioresponse)
+    mock_katsu_public_search_fields(app_config, aioresponse)
+    mock_katsu_projects(app_config, aioresponse)
+    mock_gohan_overview(app_config, aioresponse)
+    mock_katsu_individuals(app_config, aioresponse)
+    mock_katsu_public_search_query(app_config, aioresponse)
+    mock_katsu_public_search_no_query(app_config, aioresponse)
+    mock_katsu_private_search_query(app_config, aioresponse)
+    mock_katsu_private_search_overview(app_config, aioresponse)
+    mock_gohan_query(app_config, aioresponse)
+
+    response = client.get("/network")
+    assert response.status_code == 200
+    assert "beacons" in response.get_json()

--- a/tests/test_beacon_network.py
+++ b/tests/test_beacon_network.py
@@ -18,6 +18,7 @@ from .data.service_responses import (
     network_beacon_query_response_bento_18,
     katsu_config_search_fields_response,
     network_beacon_overview_bento_18_with_pr_build,
+    network_beacon_query_response_bento_18_with_pr_build,
 )
 
 
@@ -48,7 +49,7 @@ def mock_network_beacon_bento_18_query_response(aioresponse):
 
 def mock_network_beacon_bento_18_query_response_from_pr_build(aioresponse):
     url = "https://fake-patched.bento.ca/api/beacon/individuals"
-    aioresponse.post(url, payload=network_beacon_query_response_bento_18)
+    aioresponse.post(url, payload=network_beacon_query_response_bento_18_with_pr_build)
 
 
 def mock_network_katsu_public_fields_response_bento_17(aioresponse):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -360,15 +360,3 @@ def test_individuals_query_no_permissions(app_config, client, aioresponse):
     assert response.status_code == 200
     assert "responseSummary" in data
     assert data["responseSummary"]["numTotalResults"] == 0
-
-
-# --------------------------------------------------------
-# network
-# --------------------------------------------------------
-
-
-def test_network_endpoint(app_config, client, aioresponse):
-    mock_permissions_none(app_config, aioresponse)
-    response = client.get("/network")
-    assert response.status_code == 200
-    assert "beacons" in response.get_json()


### PR DESCRIPTION
The Beacon network prototype still calls the katsu instance associated with each beacon to retrieve query parameters, but without configurable katsu urls: it just guesses the urls from the beacon url. However, since Bento 18 the guesses are wrong. 

Calls to network katsus will be eliminated in the next version, so for now we can just improve the guessing. 

