### PR TITLE
add phenopackers / experiments mapping to filters

### DIFF
--- a/bento_beacon/utils/katsu_utils.py
+++ b/bento_beacon/utils/katsu_utils.py
@@ -257,8 +257,8 @@ async def katsu_config_filtering_terms(project_id, dataset_id):
                 # longer label / helptext
                 "description": field.get("description", ""),
                 #
-                # bento internal use fields, more to come
-                "bento": {"section": section["section_title"]},
+                # bento internal use fields
+                "bento": {"section": section["section_title"], "mapping": field["mapping"]},
                 #
                 # as of beacon 2.1.1
                 "values": field["options"],


### PR DESCRIPTION
Add mapping from katsu config to `/filtering_terms` response. 

The main use for this is for automatic generation of filtering terms for the beacon network: search terms with the same mappings are merged. (This was done previously using the native bento public query format but beacon now uses beacon spec filtering terms only). 
