### PR TITLE
permissions fixes

### DIFF
--- a/bento_beacon/endpoints/individuals.py
+++ b/bento_beacon/endpoints/individuals.py
@@ -88,7 +88,7 @@ async def get_individuals(project_id=None):
     individual_ids = list(reduce(set.intersection, (set(ids) for ids in individual_results.values())))
 
     if summary_stats_requested():
-        await add_stats_to_response(individual_ids)
+        await add_stats_to_response(individual_ids, project_id, dataset_id)
 
     return await build_query_response(ids=individual_ids, full_record_handler=individuals_full_results)
 

--- a/bento_beacon/utils/beacon_response.py
+++ b/bento_beacon/utils/beacon_response.py
@@ -39,9 +39,6 @@ async def add_stats_to_response(ids, project_id=None, dataset_id=None):
 
 
 async def add_overview_stats_to_response(project_id=None, dataset_id=None):
-    # TODO: check permissions
-    # should fail if you don't at least have count rights
-
     await add_stats_to_response(None, project_id, dataset_id)
 
 
@@ -50,15 +47,16 @@ async def summary_stats(ids, project_id=None, dataset_id=None):
 
     # 1. results are below threshold, so all summary stats will be below it as well
     if ids is not None and len(ids) <= (await get_censorship_threshold()):
-        return None
+        return {}
 
     # 2. user does not have count permissions at this scope
-    if not has_count_permissions(dataset_id, g.permissions):
-        return None
+    is_datset_level = dataset_id is not None
+    if not has_count_permissions(is_datset_level, g.permissions):
+        return {}
 
     # 3. count stats don't make sense for a boolean request, regardless of permissions
     if g.request_data.get("requestedGranularity") == GRANULARITY_BOOLEAN:
-        return None
+        return {}
 
     if ids is None:
         return await overview_statistics(project_id=project_id, dataset_id=dataset_id)


### PR DESCRIPTION
Permissions fixes: 
- the call for search overview stats was missing project & dataset ids (not needed for correct stats, but needed to verify permissions)
- where relevant permissions are missing, return `{}` instead of `None` (since this is passed to a python `**` unpacking operator)