### PR TITLE
Add filtering terms to network response

### DIFF
--- a/bento_beacon/network/utils/network_beacons.py
+++ b/bento_beacon/network/utils/network_beacons.py
@@ -56,8 +56,12 @@ class NetworkNode(ABC):
         pass
 
     def node_info_to_json(self):
-        # filtering terms?
-        return {**self.service_details, "apiUrl": self.api_url, "overview": self.overview}
+        return {
+            **self.service_details,
+            "apiUrl": self.api_url,
+            "overview": self.overview,
+            "filteringTerms": self.filtering_terms,
+        }
 
 
 class HostBeacon(NetworkNode):


### PR DESCRIPTION
Add filtering terms for each network node to beacon network response. Will be useful eventually in the UI. (Redmine 2689)